### PR TITLE
feat: extract Software, Hardware, and Firmware versions

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -97,6 +97,9 @@ MODULE_DETAIL_FIELDS = [
     "module_type",
     "embodiment",
     "description",
+    "software_versions",
+    "hardware_versions",
+    "firmware_versions",
     "security_policy_url",
     "algorithms",
     "algorithms_detailed",
@@ -403,6 +406,9 @@ def parse_detail_rows(panel_body) -> Dict[str, object]:
         "Module Type": "module_type",
         "Embodiment": "embodiment",
         "Description": "description",
+        "Software Versions": "software_versions",
+        "Hardware Versions": "hardware_versions",
+        "Firmware Versions": "firmware_versions",
     }
 
     for row in panel_body.find_all("div", class_="row"):
@@ -657,6 +663,9 @@ def parse_certificate_detail_page(
         "sunset_date": detail_fields.get("sunset_date") or summary_module.get("sunset_date"),
         "caveat": detail_fields.get("caveat") or summary_module.get("caveat"),
         "description": detail_fields.get("description") or summary_module.get("description"),
+        "software_versions": detail_fields.get("software_versions"),
+        "hardware_versions": detail_fields.get("hardware_versions"),
+        "firmware_versions": detail_fields.get("firmware_versions"),
         "security_level_exceptions": detail_fields.get("security_level_exceptions", []),
         "related_files": related_files,
         "validation_history": validation_history,

--- a/scraper.py
+++ b/scraper.py
@@ -1304,6 +1304,7 @@ async def process_certificate_record(
         and previous_module is not None
         and previous_detail is not None
         and previous_fingerprint == current_fingerprint
+        and "software_versions" in previous_detail
     )
 
     detail_payload: Optional[Dict] = None

--- a/scraper.py
+++ b/scraper.py
@@ -104,6 +104,11 @@ MODULE_DETAIL_FIELDS = [
     "algorithms",
     "algorithms_detailed",
 ]
+DETAIL_SCHEMA_REQUIRED_FIELDS = (
+    "software_versions",
+    "hardware_versions",
+    "firmware_versions",
+)
 
 # Algorithm keywords to look for when parsing
 # Order matters: more specific keywords should come before general ones (HMAC before SHA)
@@ -729,6 +734,20 @@ def build_certificate_fingerprint(module: Dict, dataset: str) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def should_reuse_certificate_detail(
+    previous_module: Optional[Dict],
+    previous_detail: Optional[Dict],
+    previous_fingerprint: Optional[str],
+    current_fingerprint: str,
+) -> bool:
+    """Return whether cached certificate detail HTML parsing can be skipped."""
+    if FULL_REFRESH or previous_module is None or previous_detail is None:
+        return False
+    if previous_fingerprint != current_fingerprint:
+        return False
+    return all(field in previous_detail for field in DETAIL_SCHEMA_REQUIRED_FIELDS)
+
+
 def prepare_reused_detail_payload(
     previous_detail: Dict,
     module: Dict,
@@ -1299,12 +1318,11 @@ async def process_certificate_record(
 
     current_fingerprint = build_certificate_fingerprint(module, dataset)
     previous_fingerprint = build_certificate_fingerprint(previous_module, dataset) if previous_module else None
-    fingerprint_matches = (
-        not FULL_REFRESH
-        and previous_module is not None
-        and previous_detail is not None
-        and previous_fingerprint == current_fingerprint
-        and "software_versions" in previous_detail
+    fingerprint_matches = should_reuse_certificate_detail(
+        previous_module,
+        previous_detail,
+        previous_fingerprint,
+        current_fingerprint,
     )
 
     detail_payload: Optional[Dict] = None
@@ -2373,14 +2391,21 @@ def generate_openapi_spec(
     """
     algorithms_available = bool(algorithms_summary)
 
-    # Build module schema properties from actual field names
+    # Build module schema properties from actual field names and known optional
+    # detail fields that may be absent from the first sampled record.
     sample = modules[0] if modules else {}
     module_properties = {}
-    for key, value in sample.items():
+    module_schema_values = dict(sample)
+    for key in MODULE_DETAIL_FIELDS:
+        module_schema_values.setdefault(key, None)
+    for key, value in module_schema_values.items():
         module_properties[key] = infer_openapi_schema(value)
 
     detail_properties = {}
-    for key, value in (sample_certificate_detail or {}).items():
+    detail_schema_values = dict(sample_certificate_detail or {})
+    for key in MODULE_DETAIL_FIELDS:
+        detail_schema_values.setdefault(key, None)
+    for key, value in detail_schema_values.items():
         detail_properties[key] = infer_openapi_schema(value)
 
     index_payload = build_index_payload(metadata, algorithms_summary)

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -20,6 +20,7 @@ from scraper import (
     parse_certificate_detail_page,
     parse_modules_table,
     prune_orphan_certificate_details,
+    should_reuse_certificate_detail,
     should_reuse_cached_algorithms,
 )
 
@@ -266,6 +267,18 @@ def test_parse_certificate_detail_page():
               <div class="col-md-3"><span>Description</span></div>
               <div class="col-md-9">A software library providing cryptographic functionality.</div>
             </div>
+            <div class="row padrow">
+              <div class="col-md-3"><span>Software Versions</span></div>
+              <div class="col-md-9">OpenSSL FIPS Provider 3.0.9, 3.0.10</div>
+            </div>
+            <div class="row padrow">
+              <div class="col-md-3"><span>Hardware Versions</span></div>
+              <div class="col-md-9">N/A</div>
+            </div>
+            <div class="row padrow">
+              <div class="col-md-3"><span>Firmware Versions</span></div>
+              <div class="col-md-9">Firmware 1.2.3</div>
+            </div>
           </div>
         </div>
 
@@ -343,8 +356,37 @@ def test_parse_certificate_detail_page():
     assert payload["validation_history"][1]["type"] == "Updated", "Validation history type mismatch"
     assert payload["validation_dates"] == ["3/21/2026", "4/01/2026"], "Validation dates mismatch"
     assert payload["algorithms"] == ["AES", "HMAC"], "Algorithm list mismatch"
+    assert payload["software_versions"] == "OpenSSL FIPS Provider 3.0.9, 3.0.10", "Software versions mismatch"
+    assert payload["hardware_versions"] == "N/A", "Hardware versions mismatch"
+    assert payload["firmware_versions"] == "Firmware 1.2.3", "Firmware versions mismatch"
 
     print("✓ Certificate detail page test passed")
+
+
+def test_should_reuse_certificate_detail_requires_version_schema_fields():
+    """Cached detail reuse should require every version field added to the detail schema."""
+    previous_module = {"Certificate Number": "5203", "Vendor Name": "OVH SAS"}
+    previous_detail = {"software_versions": "3.0.9"}
+    current_fingerprint = build_certificate_fingerprint(previous_module, "active")
+    previous_fingerprint = build_certificate_fingerprint(previous_module, "active")
+
+    assert not should_reuse_certificate_detail(
+        previous_module,
+        previous_detail,
+        previous_fingerprint,
+        current_fingerprint,
+    ), "Partial version schema payload should force HTML refresh"
+
+    previous_detail["hardware_versions"] = None
+    previous_detail["firmware_versions"] = None
+    assert should_reuse_certificate_detail(
+        previous_module,
+        previous_detail,
+        previous_fingerprint,
+        current_fingerprint,
+    ), "Payload with all version schema keys should be reusable"
+
+    print("✓ Certificate detail reuse schema test passed")
 
 
 def test_parse_algorithms_from_policy_text():
@@ -658,6 +700,12 @@ def test_generate_agent_docs():
     )
     assert "/api/algorithms.json" in openapi["paths"], "OpenAPI spec should include algorithms endpoint when available"
     assert openapi["components"]["schemas"]["Module"]["properties"]["detail_available"]["type"] == "boolean", "detail_available should be typed as boolean"
+    module_properties = openapi["components"]["schemas"]["Module"]["properties"]
+    certificate_properties = openapi["components"]["schemas"]["CertificateDetail"]["properties"]
+    for key in ("software_versions", "hardware_versions", "firmware_versions"):
+        assert key in module_properties, f"OpenAPI module schema should include {key}"
+        assert key in certificate_properties, f"OpenAPI certificate detail schema should include {key}"
+        assert module_properties[key]["nullable"] is True, f"OpenAPI module schema should mark {key} nullable"
 
     print("✓ Agent-friendly docs generation test passed")
 
@@ -676,6 +724,7 @@ def main():
         test_parse_historical_modules_table()
         test_parse_modules_in_process()
         test_parse_certificate_detail_page()
+        test_should_reuse_certificate_detail_requires_version_schema_fields()
         test_parse_algorithms_from_policy_text()
         test_parse_algorithms_from_legacy_policy_text()
         test_extract_legacy_algorithm_section_prefers_body_over_toc()


### PR DESCRIPTION
This PR updates the scraper to extract 'Software Versions', 'Hardware Versions', and 'Firmware Versions' from the NIST certificate detail pages and include them in the generated JSON files. This allows automated compliance tools and SBOM parsers to deterministically check version compatibility without requiring manual verification of the Security Policy PDF.