### PR TITLE
[codex] Add workflow concurrency controls

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-nist-cmvp-data-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scrape-and-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,10 +5,13 @@ on:
   push:
     branches:
       - main
-      - 'codex/**'
 
 permissions:
   contents: read
+
+concurrency:
+  group: validate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- add a concurrency group to the long-running `Update NIST CMVP Data` workflow so newer runs for the same ref cancel older in-progress runs
- keep `Validate` running on PRs and main pushes, but stop running the same validation twice for `codex/**` branch pushes
- add validation workflow concurrency keyed by PR number or ref so outdated validation runs are canceled

## Why

After merging the API validation/provenance PR, multiple full data-update workflows were still running on `main` at the same time. The live scrape can take a long time, so stacking redundant runs wastes Actions time and can produce confusing publish races.

## Validation

- `python3 validate_api.py`
- `git diff --check`

This is workflow-only; the existing PR validation workflow will run after PR creation.