### PR TITLE
[codex] Run update scraper unbuffered

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -50,9 +50,10 @@ jobs:
       - name: Run scraper
         env:
           ALGORITHM_SOURCE: crawl4ai
+          PYTHONUNBUFFERED: '1'
           SKIP_ALGORITHMS: ${{ github.event.inputs.skip_algorithms == 'true' && '1' || '0' }}
         run: |
-          python scraper.py
+          python -u scraper.py
 
       - name: Validate generated API artifacts
         run: |


### PR DESCRIPTION
## Summary

- run the update scraper with `python -u`
- set `PYTHONUNBUFFERED=1` for the scraper step

## Why

The live data update can spend a long time in the scrape step. Running Python unbuffered makes scraper progress and warning output available during the run instead of only after process exit, which improves diagnosability for long weekly updates.

## Validation

- `python3 validate_api.py`
- `git diff --check`

This is workflow-only; PR validation should run after creation.