### PR TITLE
Pipeline observability, CI tooling, change feed, and parser improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/data-freshness.yml
+++ b/.github/workflows/data-freshness.yml
@@ -1,0 +1,145 @@
+name: Data Freshness Check
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check published metadata freshness
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          live_metadata="$(mktemp)"
+          echo "Fetching published metadata from GitHub Pages..."
+          for attempt in 1 2 3; do
+            if curl -fsSL "https://hackidle.github.io/nist-cmvp-api/api/metadata.json" -o "$live_metadata"; then
+              echo "Fetched published metadata successfully."
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to fetch published metadata after 3 attempts."
+              exit 1
+            fi
+
+            echo "Fetch attempt $attempt failed; retrying in 5 seconds..."
+            sleep 5
+          done
+
+          python3 - "$live_metadata" "api/metadata.json" <<'EOF'
+          import datetime as dt
+          import json
+          import sys
+
+          live_path, repo_path = sys.argv[1], sys.argv[2]
+
+          def load_generated_at(path):
+              with open(path, "r", encoding="utf-8") as file:
+                  data = json.load(file)
+              value = data.get("generated_at")
+              if not value:
+                  raise SystemExit(f"{path} is missing generated_at")
+              try:
+                  parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+              except ValueError as exc:
+                  raise SystemExit(f"{path} has invalid generated_at {value!r}: {exc}") from exc
+              if parsed.tzinfo is None:
+                  parsed = parsed.replace(tzinfo=dt.timezone.utc)
+              return value, parsed.astimezone(dt.timezone.utc)
+
+          live_value, live_time = load_generated_at(live_path)
+          repo_value, repo_time = load_generated_at(repo_path)
+          now = dt.datetime.now(dt.timezone.utc)
+          max_age = dt.timedelta(days=8)
+          failed = False
+
+          print(f"Published generated_at: {live_value}")
+          print(f"Repository generated_at: {repo_value}")
+
+          if live_value != repo_value:
+              print("ERROR: Published metadata generated_at does not match the repository metadata; GitHub Pages may be out of sync with main.")
+              failed = True
+          else:
+              print("OK: Published metadata generated_at matches the repository metadata.")
+
+          age = now - live_time
+          print(f"Published metadata age: {age}")
+          if age > max_age:
+              print("ERROR: Published metadata is older than 8 days; data refresh appears stale.")
+              failed = True
+          else:
+              print("OK: Published metadata is not older than 8 days.")
+
+          if failed:
+              raise SystemExit(1)
+          EOF
+
+      - name: Alert on stale or out-of-sync data
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelName = 'data-freshness';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+
+            const issues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: labelName,
+              per_page: 100
+            });
+            const existingIssue = issues.data.find((issue) => !issue.pull_request);
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: `Published NIST CMVP data freshness check failed again on ${now}.\n\nRun: ${runUrl}`
+              });
+            } else {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: labelName,
+                  color: 'fbca04',
+                  description: 'Automated alert for stale or out-of-sync published NIST CMVP data'
+                });
+              } catch (error) {
+                const alreadyExists = error.status === 422 &&
+                  error.response &&
+                  error.response.data &&
+                  Array.isArray(error.response.data.errors) &&
+                  error.response.data.errors.some((item) => item.code === 'already_exists');
+                if (!alreadyExists) {
+                  throw error;
+                }
+              }
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: 'Published NIST CMVP data is stale or out of sync',
+                labels: [labelName],
+                body: `The published NIST CMVP data freshness check failed on ${now}.\n\nRun: ${runUrl}\n\nThe published API may be stale or out of sync with the repository until the data refresh and GitHub Pages publication are fixed.`
+              });
+            }

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: update-nist-cmvp-data-${{ github.ref }}
@@ -87,3 +88,59 @@ jobs:
             api/
             *.log
           retention-days: 7
+
+      - name: Alert on data refresh failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelName = 'data-refresh-failure';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString();
+
+            const issues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: labelName,
+              per_page: 100
+            });
+            const existingIssue = issues.data.find((issue) => !issue.pull_request);
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body: `Data refresh workflow failed again on ${now}.\n\nRun: ${runUrl}`
+              });
+            } else {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: labelName,
+                  color: 'd73a4a',
+                  description: 'Automated alert for NIST CMVP data refresh failures'
+                });
+              } catch (error) {
+                const alreadyExists = error.status === 422 &&
+                  error.response &&
+                  error.response.data &&
+                  Array.isArray(error.response.data.errors) &&
+                  error.response.data.errors.some((item) => item.code === 'already_exists');
+                if (!alreadyExists) {
+                  throw error;
+                }
+              }
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: 'Scheduled NIST CMVP data refresh is failing',
+                labels: [labelName],
+                body: `The scheduled NIST CMVP data refresh workflow failed on ${now}.\n\nRun: ${runUrl}\n\nThe published API may become stale until the workflow is fixed.`
+              });
+            }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,15 +31,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Compile Python files
         run: |
-          python -m py_compile scraper.py test_scraper.py validate_api.py
+          python -m py_compile scraper.py test_scraper.py validate_api.py modal_scrape.py
+
+      - name: Run ruff lint
+        run: |
+          python -m ruff check .
 
       - name: Run scraper tests
         run: |
-          python test_scraper.py
+          python -m pytest test_scraper.py -q
 
       - name: Validate checked-in API artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -212,20 +212,25 @@ python -m jsonschema modules.schema.json -i modules.json
 ## Local Development
 
 ```bash
-# Install dependencies
-pip install -r requirements.txt
+# Install lightweight test/lint dependencies
+python3 -m pip install -r requirements-dev.txt
+
+# Lint and run tests
+python3 -m ruff check .
+python3 -m pytest test_scraper.py -q
+python3 test_scraper.py
 
 # Run full scraper (Crawl4AI preferred, local PDF parser fallback)
-python scraper.py
+python3 scraper.py
 
 # Force the local PDF parser
-ALGORITHM_SOURCE=security_policy_pdf python scraper.py
+ALGORITHM_SOURCE=security_policy_pdf python3 scraper.py
 
 # Run quick scraper (skip algorithm extraction entirely)
-SKIP_ALGORITHMS=1 python scraper.py
+SKIP_ALGORITHMS=1 python3 scraper.py
 
 # Validate generated artifacts before publishing
-python validate_api.py --require-current-schema --require-supported-algorithm-source --require-data-quality-pass
+python3 validate_api.py --require-current-schema --require-supported-algorithm-source --require-data-quality-pass
 ```
 
 ## Modal Remote Runs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,5 @@ requests==2.33.1
 lxml==5.4.0
 httpx==0.28.1
 PyMuPDF==1.28.0
-crawl4ai[pdf]==0.9.0
-pyOpenSSL==26.3.0
-cryptography==49.0.0
+pytest==9.1.1
+ruff==0.15.20

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+target-version = "py312"
+
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/scraper.py
+++ b/scraper.py
@@ -18,7 +18,7 @@ Environment Variables:
     ALGORITHM_SOURCE: Override algorithm extraction source: crawl4ai, security_policy_pdf, database, none
     CMVP_DB_PATH: Path to existing cmvp.db from NIST-CMVP-ReportGen project
                   If set, algorithm data will be imported from this database
-    CERT_FETCH_CONCURRENCY: Concurrent certificate detail page fetches (default: 16)
+    CERT_FETCH_CONCURRENCY: Concurrent certificate detail page fetches (default: 8)
     PDF_FETCH_CONCURRENCY: Concurrent Security Policy PDF fetches/parses (default: 32)
     CERT_PROCESS_TIMEOUT: Per-certificate processing timeout in seconds (default: 900)
     FULL_REFRESH: Set to "1" to bypass reuse of previously generated outputs
@@ -29,6 +29,7 @@ import copy
 import hashlib
 import json
 import os
+import random
 import re
 import sqlite3
 import sys
@@ -62,7 +63,7 @@ SEARCH_PATH = os.getenv("NIST_SEARCH_PATH", "/all")
 HISTORICAL_SEARCH_PARAMS = "?SearchMode=Advanced&CertificateStatus=Historical&ValidationYear=0"
 USER_AGENT = "NIST-CMVP-Data-Scraper/1.0 (GitHub Project)"
 SKIP_ALGORITHMS = os.getenv("SKIP_ALGORITHMS", "0") == "1"
-CERT_FETCH_CONCURRENCY = max(1, int(os.getenv("CERT_FETCH_CONCURRENCY", "16")))
+CERT_FETCH_CONCURRENCY = max(1, int(os.getenv("CERT_FETCH_CONCURRENCY", "8")))
 PDF_FETCH_CONCURRENCY = max(1, int(os.getenv("PDF_FETCH_CONCURRENCY", "32")))
 CERT_PROCESS_TIMEOUT = max(1, int(os.getenv("CERT_PROCESS_TIMEOUT", "900")))
 FULL_REFRESH = os.getenv("FULL_REFRESH", "0") == "1"
@@ -355,7 +356,7 @@ def fetch_page(url: str, timeout: int = 30, retries: int = 3) -> Optional[str]:
             return response.text
         except requests.RequestException as e:
             if attempt < retries - 1:
-                wait = 2 ** (attempt + 1)
+                wait = 2 ** (attempt + 1) + random.uniform(0, 1.5)
                 print(f"Attempt {attempt + 1}/{retries} failed for {url}: {e}. Retrying in {wait}s...", file=sys.stderr)
                 time.sleep(wait)
             else:
@@ -890,6 +891,7 @@ def load_previous_outputs(output_dir: Path = Path("api")) -> Dict[str, object]:
     historical_data = load_json_file(output_dir / "historical-modules.json") or {}
     modules_in_process_data = load_json_file(output_dir / "modules-in-process.json") or {}
     metadata = load_json_file(output_dir / "metadata.json") or {}
+    data_quality = load_json_file(output_dir / "data-quality.json") or {}
     detail_payloads: Dict[int, Dict] = {}
 
     if DETAIL_DIR.exists():
@@ -915,6 +917,9 @@ def load_previous_outputs(output_dir: Path = Path("api")) -> Dict[str, object]:
             "historical": copy.deepcopy(historical_data.get("modules", [])),
         },
         "modules_in_process": copy.deepcopy(modules_in_process_data.get("modules_in_process", [])),
+        "deferred_certificates": copy.deepcopy(data_quality.get("deferred_certificates", []))
+        if isinstance(data_quality.get("deferred_certificates"), list)
+        else [],
         "modules": {
             "active": build_module_map(active_data.get("modules", [])),
             "historical": build_module_map(historical_data.get("modules", [])),
@@ -1473,7 +1478,7 @@ async def fetch_with_retry(
     client: httpx.AsyncClient,
     url: str,
     response_type: str = "text",
-    retries: int = 3,
+    retries: int = 4,
 ) -> Optional[object]:
     """Fetch a URL asynchronously with retries for transient failures."""
     for attempt in range(retries):
@@ -1490,14 +1495,14 @@ async def fetch_with_retry(
             if exc.response.status_code < 500 or attempt == retries - 1:
                 print(f"Error fetching {url}: {exc}", file=sys.stderr)
                 return None
-            wait = 2 ** (attempt + 1)
+            wait = 2 ** (attempt + 1) + random.uniform(0, 1.5)
             print(f"Attempt {attempt + 1}/{retries} failed for {url}: {exc}. Retrying in {wait}s...", file=sys.stderr)
             await asyncio.sleep(wait)
         except httpx.RequestError as exc:
             if attempt == retries - 1:
                 print(f"Error fetching {url}: {exc}", file=sys.stderr)
                 return None
-            wait = 2 ** (attempt + 1)
+            wait = 2 ** (attempt + 1) + random.uniform(0, 1.5)
             print(f"Attempt {attempt + 1}/{retries} failed for {url}: {exc}. Retrying in {wait}s...", file=sys.stderr)
             await asyncio.sleep(wait)
     return None
@@ -2130,7 +2135,8 @@ async def build_certificate_artifacts(
     algorithm_source: str,
     previous_outputs: Dict[str, object],
     database_algorithms_map: Optional[Dict[int, List[str]]] = None,
-) -> Tuple[List[Dict], Dict[int, Dict], Dict[int, List[str]], Dict[str, int]]:
+    include_deferred: bool = False,
+) -> Tuple:
     """Build enriched module rows, certificate detail payloads, and algorithms for a dataset."""
     previous_modules = previous_outputs.get("modules", {}).get(dataset, {})
     previous_details = previous_outputs.get("details", {})
@@ -2140,6 +2146,7 @@ async def build_certificate_artifacts(
     results: List[Optional[Dict]] = [None] * len(modules)
     payloads: Dict[int, Dict] = {}
     algorithms_map: Dict[int, List[str]] = {}
+    deferred_certificates: List[Dict] = []
     stats = new_processing_stats()
 
     timeout = httpx.Timeout(30.0)
@@ -2202,6 +2209,13 @@ async def build_certificate_artifacts(
                 cert_number = parse_certificate_number(module_out)
                 deferred_reason = module_out.pop(DEFERRED_REASON_KEY, None)
                 if deferred_reason:
+                    deferred_certificates.append(
+                        {
+                            "certificate_number": str(cert_number) if cert_number is not None else None,
+                            "dataset": dataset,
+                            "reason": deferred_reason,
+                        }
+                    )
                     print(
                         f"  Deferred certificate {cert_number or 'unknown'} ({dataset}): {deferred_reason}",
                         file=sys.stderr,
@@ -2230,7 +2244,10 @@ async def build_certificate_artifacts(
                         f"{stats['html_failed']} failed, {stats['certificates_deferred']} deferred)"
                     )
 
-    return [result for result in results if result], payloads, algorithms_map, stats
+    artifacts = ([result for result in results if result], payloads, algorithms_map, stats)
+    if include_deferred:
+        return (*artifacts, deferred_certificates)
+    return artifacts
 
 
 def parse_modules_table(html: str) -> List[Dict]:
@@ -2790,6 +2807,101 @@ def quality_certificate_record(
     return record
 
 
+def deferred_certificate_key(record: Dict) -> Tuple[Optional[str], Optional[str]]:
+    """Return the stable key used to identify repeated certificate deferrals."""
+    cert_number = record.get("certificate_number")
+    if cert_number is not None:
+        cert_number = str(cert_number)
+    dataset = record.get("dataset")
+    return cert_number, str(dataset) if dataset is not None else None
+
+
+def mark_deferred_certificates(
+    deferred_certificates: Optional[List[Dict]],
+    previous_deferred_certificates: Optional[List[Dict]],
+) -> List[Dict]:
+    """Attach repeat flags for certificates deferred in consecutive runs."""
+    previous_keys = {
+        deferred_certificate_key(record)
+        for record in previous_deferred_certificates or []
+        if isinstance(record, dict)
+    }
+    marked: List[Dict] = []
+    for record in deferred_certificates or []:
+        if not isinstance(record, dict):
+            continue
+        cert_number = record.get("certificate_number")
+        normalized = {
+            "certificate_number": str(cert_number) if cert_number is not None else None,
+            "dataset": record.get("dataset"),
+            "reason": record.get("reason"),
+        }
+        repeat = deferred_certificate_key(normalized) in previous_keys
+        normalized["repeat"] = repeat
+        if repeat:
+            cert_label = normalized["certificate_number"] or "unknown"
+            print(f"Warning: certificate {cert_label} deferred in consecutive runs", file=sys.stderr)
+        marked.append(normalized)
+    return marked
+
+
+def classify_zero_algorithm_certificate(extraction: Dict) -> str:
+    """Classify why a certificate has no algorithm rows."""
+    attempts = extraction.get("attempts") or []
+    if isinstance(attempts, list) and any(
+        isinstance(attempt, dict) and attempt.get("status") == "no_algorithms"
+        for attempt in attempts
+    ):
+        return "explicit_no_algorithms"
+    if extraction.get("source") == "none":
+        return "source_none"
+    if extraction.get("cached") is True and not attempts:
+        return "cached_no_attempts"
+    return "other"
+
+
+def build_algorithm_coverage_report(
+    modules: List[Dict],
+    historical_modules: List[Dict],
+    detail_payloads: Dict[int, Dict],
+) -> Dict:
+    """Summarize algorithm extraction coverage without affecting quality gates."""
+    buckets = {
+        "cached_no_attempts": 0,
+        "explicit_no_algorithms": 0,
+        "source_none": 0,
+        "other": 0,
+    }
+    total_certificates = 0
+    certificates_with_algorithms = 0
+
+    for records in (modules, historical_modules):
+        for module in records:
+            total_certificates += 1
+            cert_number = parse_certificate_number(module)
+            detail_payload = detail_payloads.get(cert_number) if cert_number is not None else None
+            algorithms = normalize_string_list(
+                (detail_payload or {}).get("algorithms") or module.get("algorithms") or []
+            )
+            if algorithms:
+                certificates_with_algorithms += 1
+                continue
+
+            extraction = first_non_empty(
+                (detail_payload or {}).get("algorithm_extraction"),
+                module.get("algorithm_extraction"),
+            )
+            bucket = classify_zero_algorithm_certificate(extraction) if isinstance(extraction, dict) else "other"
+            buckets[bucket] += 1
+
+    return {
+        "total_certificates": total_certificates,
+        "certificates_with_algorithms": certificates_with_algorithms,
+        "coverage_rate": safe_ratio(certificates_with_algorithms, total_certificates) or 0,
+        "zero_algorithm_certificates": buckets,
+    }
+
+
 def build_update_monitor(metadata: Dict, combined_metrics: Dict[str, int]) -> Dict:
     """Build a small run-health summary that can be monitored after each update."""
     html_total = (
@@ -2864,12 +2976,16 @@ def build_data_quality_report(
     previous_outputs: Dict[str, object],
     active_stats: Dict[str, int],
     historical_stats: Dict[str, int],
+    deferred_certificates: Optional[List[Dict]] = None,
 ) -> Dict:
     """Build a compact report of misses, refreshes, fallbacks, and changed certs."""
     previous_modules = previous_outputs.get("modules", {}) if isinstance(previous_outputs, dict) else {}
     previous_details = previous_outputs.get("details", {}) if isinstance(previous_outputs, dict) else {}
+    previous_deferred = previous_outputs.get("deferred_certificates", []) if isinstance(previous_outputs, dict) else []
     extraction_metrics = metadata.get("extraction_metrics") or build_extraction_metrics(active_stats, historical_stats)
     combined_metrics = extraction_metrics.get("combined") or combine_processing_stats(active_stats, historical_stats)
+    marked_deferred = mark_deferred_certificates(deferred_certificates, previous_deferred)
+    algorithm_coverage = build_algorithm_coverage_report(modules, historical_modules, detail_payloads)
 
     misses: List[Dict] = []
     refreshed_records: List[Dict] = []
@@ -2936,8 +3052,11 @@ def build_data_quality_report(
             "refreshed_records": len(refreshed_records),
             "fallback_usage": len(fallback_usage),
             "changed_certificates": len(changed_certificates),
+            "deferred": len(marked_deferred),
         },
         "update_monitor": build_update_monitor(metadata, combined_metrics),
+        "algorithm_coverage": algorithm_coverage,
+        "deferred_certificates": marked_deferred,
         "misses": misses,
         "refreshed_records": refreshed_records,
         "fallback_usage": fallback_usage,
@@ -4029,6 +4148,48 @@ def data_quality_schema() -> Dict:
             "reason": {"type": "string"},
         },
     }
+    deferred_record_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["certificate_number", "dataset", "reason", "repeat"],
+        "properties": {
+            "certificate_number": {"type": ["string", "null"]},
+            "dataset": {"type": "string", "enum": ["active", "historical"]},
+            "reason": {"type": "string"},
+            "repeat": {"type": "boolean"},
+        },
+    }
+    algorithm_coverage_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "total_certificates",
+            "certificates_with_algorithms",
+            "coverage_rate",
+            "zero_algorithm_certificates",
+        ],
+        "properties": {
+            "total_certificates": {"type": "integer", "minimum": 0},
+            "certificates_with_algorithms": {"type": "integer", "minimum": 0},
+            "coverage_rate": {"type": "number", "minimum": 0, "maximum": 1},
+            "zero_algorithm_certificates": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "cached_no_attempts",
+                    "explicit_no_algorithms",
+                    "source_none",
+                    "other",
+                ],
+                "properties": {
+                    "cached_no_attempts": {"type": "integer", "minimum": 0},
+                    "explicit_no_algorithms": {"type": "integer", "minimum": 0},
+                    "source_none": {"type": "integer", "minimum": 0},
+                    "other": {"type": "integer", "minimum": 0},
+                },
+            },
+        },
+    }
     return {
         "type": "object",
         "additionalProperties": False,
@@ -4065,6 +4226,8 @@ def data_quality_schema() -> Dict:
             "refreshed_records": {"type": "array", "items": quality_record_schema},
             "fallback_usage": {"type": "array", "items": quality_record_schema},
             "changed_certificates": {"type": "array", "items": quality_record_schema},
+            "deferred_certificates": {"type": "array", "items": deferred_record_schema},
+            "algorithm_coverage": algorithm_coverage_schema,
         },
     }
 
@@ -4661,6 +4824,19 @@ def generate_openapi_spec(
                         "metadata": {"$ref": "#/components/schemas/Metadata"},
                         "summary": {"type": "object", "additionalProperties": {"type": "integer"}},
                         "update_monitor": {"type": "object", "additionalProperties": True},
+                        "algorithm_coverage": {"type": "object", "additionalProperties": True},
+                        "deferred_certificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "certificate_number": {"type": "string", "nullable": True},
+                                    "dataset": {"type": "string", "enum": ["active", "historical"]},
+                                    "reason": {"type": "string"},
+                                    "repeat": {"type": "boolean"},
+                                },
+                            },
+                        },
                         "misses": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
                         "refreshed_records": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
                         "fallback_usage": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
@@ -4933,9 +5109,10 @@ def main():
 
     certificate_detail_payloads: Dict[int, Dict] = {}
     algorithms_map: Dict[int, List[str]] = {}
+    deferred_certificates: List[Dict] = []
 
     print("\nBuilding active certificate records...")
-    modules, active_payloads, active_algorithms, active_stats = asyncio.run(
+    modules, active_payloads, active_algorithms, active_stats, active_deferred = asyncio.run(
         build_certificate_artifacts(
             modules,
             "active",
@@ -4943,13 +5120,15 @@ def main():
             algorithm_source,
             previous_outputs,
             database_algorithms_map,
+            include_deferred=True,
         )
     )
     certificate_detail_payloads.update(active_payloads)
     algorithms_map.update(active_algorithms)
+    deferred_certificates.extend(active_deferred)
 
     print("\nBuilding historical certificate records...")
-    historical_modules, historical_payloads, historical_algorithms, historical_stats = asyncio.run(
+    historical_modules, historical_payloads, historical_algorithms, historical_stats, historical_deferred = asyncio.run(
         build_certificate_artifacts(
             historical_modules,
             "historical",
@@ -4957,10 +5136,12 @@ def main():
             algorithm_source,
             previous_outputs,
             database_algorithms_map,
+            include_deferred=True,
         )
     )
     certificate_detail_payloads.update(historical_payloads)
     algorithms_map.update(historical_algorithms)
+    deferred_certificates.extend(historical_deferred)
 
     extraction_metrics = build_extraction_metrics(active_stats, historical_stats)
 
@@ -5044,6 +5225,7 @@ def main():
         previous_outputs,
         active_stats,
         historical_stats,
+        deferred_certificates,
     )
     save_json(data_quality_report, f"{output_dir}/data-quality.json")
     save_json(build_examples_payload(metadata), f"{output_dir}/examples.json")

--- a/scraper.py
+++ b/scraper.py
@@ -81,6 +81,7 @@ CRAWL4AI_ALGORITHM_SOURCE = "crawl4ai"
 SECURITY_POLICY_ALGORITHM_SOURCE = "security_policy_pdf"
 ALGORITHM_CACHE_VERSION = "2026-04-15-legacy-v1"
 ALGORITHM_EXTRACTION_SCHEMA_VERSION = "1.0"
+CHANGE_FEED_MAX_RUNS = 26
 CACHEABLE_ALGORITHM_SOURCES = {
     CRAWL4AI_ALGORITHM_SOURCE,
     SECURITY_POLICY_ALGORITHM_SOURCE,
@@ -892,6 +893,7 @@ def load_previous_outputs(output_dir: Path = Path("api")) -> Dict[str, object]:
     modules_in_process_data = load_json_file(output_dir / "modules-in-process.json") or {}
     metadata = load_json_file(output_dir / "metadata.json") or {}
     data_quality = load_json_file(output_dir / "data-quality.json") or {}
+    changes = load_json_file(output_dir / "changes.json")
     detail_payloads: Dict[int, Dict] = {}
 
     if DETAIL_DIR.exists():
@@ -925,6 +927,7 @@ def load_previous_outputs(output_dir: Path = Path("api")) -> Dict[str, object]:
             "historical": build_module_map(historical_data.get("modules", [])),
         },
         "details": detail_payloads,
+        "changes": copy.deepcopy(changes) if isinstance(changes, dict) else None,
     }
 
 
@@ -3064,6 +3067,100 @@ def build_data_quality_report(
     }
 
 
+def changes_module_map(records: List[Dict]) -> Dict[int, Dict]:
+    """Return a certificate-number keyed map for change feed comparisons."""
+    mapping: Dict[int, Dict] = {}
+    for record in records or []:
+        cert_number = parse_certificate_number(record)
+        if cert_number is not None:
+            mapping[cert_number] = record
+    return mapping
+
+
+def certificate_number_strings(cert_numbers: Set[int]) -> List[str]:
+    """Return numerically sorted certificate numbers as API strings."""
+    return [str(cert_number) for cert_number in sorted(cert_numbers)]
+
+
+def changed_summary_certificates(current_modules: Dict[int, Dict], previous_modules: Dict[int, Dict], dataset: str) -> Set[int]:
+    """Return certificates whose summary fingerprint changed within a dataset."""
+    changed: Set[int] = set()
+    for cert_number in set(current_modules) & set(previous_modules):
+        current_fingerprint = build_certificate_fingerprint(current_modules[cert_number], dataset)
+        previous_fingerprint = build_certificate_fingerprint(previous_modules[cert_number], dataset)
+        if current_fingerprint != previous_fingerprint:
+            changed.add(cert_number)
+    return changed
+
+
+def build_changes_feed(
+    metadata: Dict,
+    modules: List[Dict],
+    historical_modules: List[Dict],
+    previous_outputs: Dict[str, object],
+    previous_changes: Optional[Dict],
+) -> Dict:
+    """Build the cumulative, capped newest-first certificate change feed."""
+    previous_outputs = previous_outputs if isinstance(previous_outputs, dict) else {}
+    previous_modules = previous_outputs.get("modules", {})
+    previous_modules = previous_modules if isinstance(previous_modules, dict) else {}
+    previous_active = previous_modules.get("active", {})
+    previous_historical = previous_modules.get("historical", {})
+    previous_active = previous_active if isinstance(previous_active, dict) else {}
+    previous_historical = previous_historical if isinstance(previous_historical, dict) else {}
+
+    current_active = changes_module_map(modules)
+    current_historical = changes_module_map(historical_modules)
+    has_previous_modules = bool(previous_active or previous_historical)
+
+    if has_previous_modules:
+        previous_all = set(previous_active) | set(previous_historical)
+        current_all = set(current_active) | set(current_historical)
+        added_active = set(current_active) - set(previous_active)
+        added_historical = set(current_historical) - set(previous_historical)
+        removed = previous_all - current_all
+        changed = (
+            changed_summary_certificates(current_active, previous_active, "active")
+            | changed_summary_certificates(current_historical, previous_historical, "historical")
+        )
+    else:
+        added_active = set()
+        added_historical = set()
+        removed = set()
+        changed = set()
+
+    current_run = {
+        "generated_at": metadata.get("generated_at"),
+        "added_active": certificate_number_strings(added_active),
+        "added_historical": certificate_number_strings(added_historical),
+        "removed": certificate_number_strings(removed),
+        "changed": certificate_number_strings(changed),
+    }
+    current_run["counts"] = {
+        key: len(current_run[key])
+        for key in ("added_active", "added_historical", "removed", "changed")
+    }
+
+    prior_runs = []
+    previous_total_runs = 0
+    if isinstance(previous_changes, dict):
+        runs = previous_changes.get("runs")
+        if isinstance(runs, list):
+            prior_runs = [copy.deepcopy(run) for run in runs if isinstance(run, dict)]
+        total_runs = previous_changes.get("total_runs")
+        if isinstance(total_runs, int) and total_runs >= 0:
+            previous_total_runs = total_runs
+    previous_total_runs = max(previous_total_runs, len(prior_runs))
+
+    runs = [current_run, *prior_runs][:CHANGE_FEED_MAX_RUNS]
+    return {
+        "metadata": metadata,
+        "max_runs": CHANGE_FEED_MAX_RUNS,
+        "total_runs": previous_total_runs + 1,
+        "runs": runs,
+    }
+
+
 def compact_search_index_reference(entry: Dict) -> Dict:
     """Return a compact certificate reference for search-friendly indexes."""
     return {
@@ -3319,6 +3416,7 @@ def schema_paths(algorithms_summary: Optional[Dict] = None) -> Dict[str, str]:
         "certificate_index": "/api/schemas/certificate-index.schema.json",
         "certificate_detail": "/api/schemas/certificate-detail.schema.json",
         "data_quality": "/api/schemas/data-quality.schema.json",
+        "changes": "/api/schemas/changes.schema.json",
         "examples": "/api/schemas/examples.schema.json",
         "search_index": "/api/schemas/search-index.schema.json",
     }
@@ -3469,6 +3567,9 @@ def build_api_reference_body(
         "### Data Quality",
         "`GET api/data-quality.json` — Latest run quality report with misses, refreshed records, fallback usage, changed certificates, cache reuse checks, and the next scheduled weekly run.",
         "",
+        "### Changes",
+        "`GET api/changes.json` — Cumulative newest-first feed of added, removed, and summary-changed certificate numbers across recent weekly runs.",
+        "",
         "### Consumer Examples",
         "`GET api/examples.json` — Copy-ready curl, Python, JavaScript, and agent-oriented query examples for vendor, module, algorithm, status, and standard lookups.",
         "",
@@ -3542,6 +3643,7 @@ def build_api_reference_body(
             "GET api/index.json → endpoints, docs links, feature flags, counts",
             "GET api/metadata.json → freshness, scrape provenance, and extraction metrics",
             "GET api/data-quality.json → latest run misses, refreshes, fallbacks, changed certs, and next scheduled run",
+            "GET api/changes.json → recent added, removed, and summary-changed certificate numbers",
             "```",
             "",
             "### Find a module and pull the full certificate record",
@@ -3607,6 +3709,7 @@ def build_llms_txt(metadata: Dict, algorithms_summary: Optional[Dict]) -> str:
         "- `api/certificates/{certificate}.json` — full detail record for a single CMVP certificate.",
         "- `api/indexes/vendors.json`, `api/indexes/algorithms.json`, `api/indexes/statuses.json`, `api/indexes/standards.json` — split search indexes for common filters.",
         "- `api/data-quality.json` — latest run misses, refreshes, fallbacks, changed certs, and weekly run checks.",
+        "- `api/changes.json` — cumulative newest-first change feed for recent weekly runs.",
         "- `api/examples.json` — curl, Python, JavaScript, and agent-oriented lookup examples.",
     ]
     if algorithms_summary:
@@ -4232,6 +4335,53 @@ def data_quality_schema() -> Dict:
     }
 
 
+def changes_schema() -> Dict:
+    """Return the cumulative changes feed response schema."""
+    certificate_list_schema = {"type": "array", "items": {"type": "string", "pattern": "^[0-9]+$"}}
+    counts_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["added_active", "added_historical", "removed", "changed"],
+        "properties": {
+            "added_active": {"type": "integer", "minimum": 0},
+            "added_historical": {"type": "integer", "minimum": 0},
+            "removed": {"type": "integer", "minimum": 0},
+            "changed": {"type": "integer", "minimum": 0},
+        },
+    }
+    run_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "generated_at",
+            "added_active",
+            "added_historical",
+            "removed",
+            "changed",
+            "counts",
+        ],
+        "properties": {
+            "generated_at": {"type": "string", "format": "date-time"},
+            "added_active": certificate_list_schema,
+            "added_historical": certificate_list_schema,
+            "removed": certificate_list_schema,
+            "changed": certificate_list_schema,
+            "counts": counts_schema,
+        },
+    }
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["metadata", "max_runs", "total_runs", "runs"],
+        "properties": {
+            "metadata": {"$ref": "/api/schemas/metadata.schema.json"},
+            "max_runs": {"type": "integer", "minimum": 1},
+            "total_runs": {"type": "integer", "minimum": 0},
+            "runs": {"type": "array", "items": run_schema},
+        },
+    }
+
+
 def examples_schema() -> Dict:
     """Return the consumer examples response schema."""
     return {
@@ -4378,6 +4528,11 @@ def generate_json_schema_artifacts(algorithms_summary: Optional[Dict]) -> Dict[s
             paths["data_quality"],
             data_quality_schema(),
         ),
+        "api/schemas/changes.schema.json": json_schema_document(
+            "NIST CMVP Changes Feed",
+            paths["changes"],
+            changes_schema(),
+        ),
         "api/schemas/examples.schema.json": json_schema_document(
             "NIST CMVP Consumer Examples",
             paths["examples"],
@@ -4409,6 +4564,7 @@ def build_index_payload(metadata: Dict, algorithms_summary: Optional[Dict]) -> D
         "certificate_index": "/api/certificates/index.json",
         "certificate_detail_template": "/api/certificates/{certificate}.json",
         "data_quality": "/api/data-quality.json",
+        "changes": "/api/changes.json",
         "examples": "/api/examples.json",
         "vendor_index": "/api/indexes/vendors.json",
         "algorithm_index": "/api/indexes/algorithms.json",
@@ -4438,6 +4594,7 @@ def build_index_payload(metadata: Dict, algorithms_summary: Optional[Dict]) -> D
             "algorithm_extraction_provenance": True,
             "extraction_metrics": True,
             "data_quality_report": True,
+            "changes_feed": True,
             "consumer_examples": True,
             "search_indexes": True,
             "certificate_index": True,
@@ -4588,6 +4745,22 @@ def generate_openapi_spec(
                             "content": {
                                 "application/json": {
                                     "schema": {"$ref": "#/components/schemas/DataQualityReport"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/api/changes.json": {
+                "get": {
+                    "summary": "Cumulative certificate change feed",
+                    "operationId": "getChanges",
+                    "responses": {
+                        "200": {
+                            "description": "Newest-first feed of added, removed, and summary-changed certificate numbers",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/ChangesResponse"}
                                 }
                             }
                         }
@@ -4843,6 +5016,31 @@ def generate_openapi_spec(
                         "changed_certificates": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
                     },
                 },
+                "ChangesResponse": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {"$ref": "#/components/schemas/Metadata"},
+                        "max_runs": {"type": "integer"},
+                        "total_runs": {"type": "integer"},
+                        "runs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "generated_at": {"type": "string", "format": "date-time"},
+                                    "added_active": {"type": "array", "items": {"type": "string"}},
+                                    "added_historical": {"type": "array", "items": {"type": "string"}},
+                                    "removed": {"type": "array", "items": {"type": "string"}},
+                                    "changed": {"type": "array", "items": {"type": "string"}},
+                                    "counts": {
+                                        "type": "object",
+                                        "additionalProperties": {"type": "integer"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
                 "ExamplesResponse": {
                     "type": "object",
                     "properties": {
@@ -5059,6 +5257,7 @@ def main():
         "modules_in_process": [],
         "modules": {"active": {}, "historical": {}},
         "details": {},
+        "changes": None,
     }
     if not FULL_REFRESH:
         cached_detail_count = len(previous_outputs.get("details", {}))
@@ -5228,6 +5427,14 @@ def main():
         deferred_certificates,
     )
     save_json(data_quality_report, f"{output_dir}/data-quality.json")
+    changes_feed = build_changes_feed(
+        metadata,
+        modules,
+        historical_modules,
+        previous_outputs,
+        previous_outputs.get("changes"),
+    )
+    save_json(changes_feed, f"{output_dir}/changes.json")
     save_json(build_examples_payload(metadata), f"{output_dir}/examples.json")
 
     algorithms_summary = None

--- a/scraper.py
+++ b/scraper.py
@@ -160,9 +160,13 @@ PDF_SECTION_LABELS = {
 LEGACY_SECTION_STOP_PATTERNS = (
     r"\n\s*Table\s+\d+\s+(?:FIPS\s+)?Non-Approved\s+Cryptographic\s+Functions\b",
     r"\n\s*Table\s+\d+\s+Non-Approved\s+Cryptographic\s+Algorithms\b",
+    r"\n\s*Table\s+\d+\s+describes\s+the\s+(?:non[-\s]?approved|non[-\s]?FIPS[-\s]+approved)(?:\s+but\s+allowed)?\s+algorithms\b",
     r"\n\s*\d+\.\d+(?:\.\d+)?\s+FIPS\s+Non-Approved\b",
     r"\n\s*\d+\.\d+(?:\.\d+)?\s+Non-Approved\b",
     r"\n\s*3\.5(?:\.1)?\s+(?:Allowed|Non-Approved)\s+Algorithms\b",
+    r"\n\s*Allowed\s+Algorithms\b",
+    r"\n\s*(?:FIPS\s+)?Non[-\s]?Approved(?:\s+but\s+Allowed)?\s+Algorithms\b",
+    r"\n\s*Non[-\s]?FIPS[-\s]+Approved(?:\s+but\s+Allowed)?\s+Algorithms\b",
     r"\n\s*\d+\.\d+(?:\.\d+)?\s+Critical\s+Security\s+Parameters\b",
     r"\n\s*\d+\.\d+(?:\.\d+)?\s+General\s+Public\s+Keys\b",
     r"\n\s*2\.\s+[A-Za-z]",
@@ -171,6 +175,11 @@ LEGACY_SECTION_STOP_PATTERNS = (
     r"\n\s*5\.\d+\s+[A-Za-z]",
     r"\n\s*6\.\d+\s+[A-Za-z]",
     r"\n\s*\d+\s+Cryptographic Key Management\b",
+)
+LEGACY_SECTION_STOP_RE = re.compile("|".join(LEGACY_SECTION_STOP_PATTERNS), re.IGNORECASE)
+LEGACY_CERT_REFERENCE_RE = re.compile(
+    r"\b(?:Cert\.?|Certificate)\s*#\s*[A-Za-z0-9-]+",
+    re.IGNORECASE,
 )
 PDF_NOISE_PREFIXES = (
     "copyright",
@@ -1161,6 +1170,7 @@ def extract_legacy_algorithm_section(policy_text: str) -> str:
         r"Table\s+\d+\s+Approved\s+Cryptographic\s+Algorithms\b",
         r"Table\s+\d+\s+Approved\s+Algorithms\b",
         r"Table\s+\d+\s+below\s+lists\s+the\s+FIPS\s+Approved\s+cryptographic\s+algorithms\b",
+        r"Table\s+\d+\s+(?:below\s+)?lists\s+the\s+(?:FIPS[-\s]+)?Approved\s+(?:cryptographic\s+)?algorithms\b",
         r"3\.4\s+Algorithms\b",
         r"Approved\s+Cryptographic\s+Functions\b",
     ]
@@ -1174,14 +1184,13 @@ def extract_legacy_algorithm_section(policy_text: str) -> str:
     if not matches:
         return ""
 
-    stop_pattern = "|".join(LEGACY_SECTION_STOP_PATTERNS)
     best_section = ""
     best_score = (-1, -1)
 
     for match in matches:
         start = match.start()
         tail = policy_text[start:]
-        end_match = re.search(stop_pattern, tail, flags=re.IGNORECASE)
+        end_match = LEGACY_SECTION_STOP_RE.search(tail)
         end = start + end_match.start() if end_match else len(policy_text)
         section = policy_text[start:end]
         if not section:
@@ -1285,6 +1294,43 @@ def categorize_algorithm_entry(entry: str) -> List[str]:
     return normalized
 
 
+def is_legacy_section_stop_line(line: str) -> bool:
+    """Return True when a legacy policy line starts the next algorithm block."""
+    return bool(LEGACY_SECTION_STOP_RE.search(f"\n{line}"))
+
+
+def parse_legacy_algorithm_rows(section: str) -> List[str]:
+    """Extract detailed legacy algorithm rows that include CAVP certificate references."""
+    entries: List[str] = []
+
+    for raw_line in section.splitlines():
+        line = normalize_whitespace(raw_line)
+        if not line:
+            continue
+        if is_legacy_section_stop_line(line):
+            break
+
+        lower = line.lower()
+        if lower in LEGACY_TABLE_HEADER_LINES:
+            continue
+        if lower.startswith("table "):
+            continue
+        if "non-approved" in lower:
+            continue
+        if "approved mode" in lower:
+            continue
+        if not LEGACY_CERT_REFERENCE_RE.search(line):
+            continue
+        if not categorize_algorithm_entry(line):
+            continue
+
+        entry = format_algorithm_entry([line])
+        if entry and entry not in entries:
+            entries.append(entry)
+
+    return entries
+
+
 def parse_categories_from_legacy_section(section: str) -> List[str]:
     """Recover coarse algorithm coverage from older approved-algorithm sections."""
     categories: Set[str] = set()
@@ -1293,6 +1339,8 @@ def parse_categories_from_legacy_section(section: str) -> List[str]:
         line = normalize_whitespace(raw_line)
         if not line:
             continue
+        if is_legacy_section_stop_line(line):
+            break
 
         lower = line.lower()
         if lower in LEGACY_TABLE_HEADER_LINES:
@@ -1321,7 +1369,10 @@ def parse_algorithms_from_policy_text(policy_text: str) -> Tuple[List[str], List
         legacy_section = extract_legacy_algorithm_section(policy_text)
         if not legacy_section:
             return [], []
-        return [], parse_categories_from_legacy_section(legacy_section)
+        return (
+            parse_legacy_algorithm_rows(legacy_section),
+            parse_categories_from_legacy_section(legacy_section),
+        )
 
     entries: List[str] = []
     categories: Set[str] = set()

--- a/scraper.py
+++ b/scraper.py
@@ -1013,8 +1013,8 @@ def prepare_reused_detail_payload(
     payload["security_policy_url"] = payload.get("security_policy_url") or module.get("security_policy_url")
     payload["vendor_name"] = payload.get("vendor_name") or module.get("Vendor Name")
     payload["module_name"] = payload.get("module_name") or module.get("Module Name")
-    for field in DETAIL_SCHEMA_MIGRATED_FIELDS:
-        payload.setdefault(field, None)
+    for schema_field in DETAIL_SCHEMA_MIGRATED_FIELDS:
+        payload.setdefault(schema_field, None)
     return payload
 
 
@@ -2334,7 +2334,7 @@ def scrape_all_modules() -> List[Dict]:
     # Construct the search URL using BASE_URL and SEARCH_PATH
     url = f"{BASE_URL}{SEARCH_PATH}"
     print(f"Fetching: {url}")
-    print(f"Note: If this URL is incorrect, set NIST_SEARCH_PATH environment variable")
+    print("Note: If this URL is incorrect, set NIST_SEARCH_PATH environment variable")
     
     html = fetch_page(url)
     if not html:
@@ -2752,14 +2752,14 @@ def changed_fingerprint_fields(module: Dict, previous_module: Optional[Dict]) ->
     if not previous_module:
         return []
     changes = []
-    for field in CACHE_FINGERPRINT_FIELDS:
-        previous_value = previous_module.get(field)
-        current_value = module.get(field)
+    for cache_field in CACHE_FINGERPRINT_FIELDS:
+        previous_value = previous_module.get(cache_field)
+        current_value = module.get(cache_field)
         if previous_value == current_value:
             continue
         changes.append(
             {
-                "field": field,
+                "field": cache_field,
                 "previous": previous_value,
                 "current": current_value,
             }
@@ -3396,7 +3396,7 @@ def build_api_reference_body(
     lines.extend(
         [
             "### Certificate Details",
-            f"`GET api/certificates/{{certificate}}.json` — Structured detail record for a specific certificate, including vendor/contact data, related files, validation history, and extracted algorithms when available.",
+            "`GET api/certificates/{certificate}.json` — Structured detail record for a specific certificate, including vendor/contact data, related files, validation history, and extracted algorithms when available.",
             "",
             "Example response (truncated):",
             "",
@@ -3485,7 +3485,7 @@ def build_llms_txt(metadata: Dict, algorithms_summary: Optional[Dict]) -> str:
         f"- `api/modules-in-process.json` — {format_count(metadata.get('total_modules_in_process', 0))} modules currently in process.",
         "- `api/metadata.json` — generation timestamp, counts, source URLs, and extraction metrics.",
         f"- `api/certificates/index.json` — compact index for {format_count(metadata.get('total_certificate_details', 0))} certificate detail files.",
-        f"- `api/certificates/{{certificate}}.json` — full detail record for a single CMVP certificate.",
+        "- `api/certificates/{certificate}.json` — full detail record for a single CMVP certificate.",
         "- `api/indexes/vendors.json`, `api/indexes/algorithms.json`, `api/indexes/statuses.json`, `api/indexes/standards.json` — split search indexes for common filters.",
         "- `api/data-quality.json` — latest run misses, refreshes, fallbacks, changed certs, and weekly run checks.",
         "- `api/examples.json` — curl, Python, JavaScript, and agent-oriented lookup examples.",
@@ -5112,7 +5112,7 @@ def main():
     print("\n" + "=" * 60)
     print("Scraping completed successfully!")
     print("=" * 60)
-    print(f"\nSummary:")
+    print("\nSummary:")
     print(f"  - Validated modules: {len(modules)}")
     print(f"  - Historical modules: {len(historical_modules)}")
     print(f"  - Modules in process: {len(modules_in_process)}")
@@ -5145,7 +5145,7 @@ def main():
             f"{historical_stats['pdf_failed']} failed, {historical_stats['pdf_cache_hits']} PDF cache hits, "
             f"{historical_stats['algorithm_misses']} misses"
         )
-    print(f"  - OpenAPI spec: openapi.json")
+    print("  - OpenAPI spec: openapi.json")
     print(f"\nOutput files saved to: {output_dir}/")
 
 

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -5,6 +5,7 @@ Tests the parsing logic with sample HTML.
 """
 
 import asyncio
+import io
 import sys
 import tempfile
 from pathlib import Path
@@ -1071,6 +1072,51 @@ def test_fetch_policy_pdf_bytes_shields_shared_cache_task_from_cancellation():
     print("✓ Policy PDF cache cancellation shielding test passed")
 
 
+def test_fetch_with_retry_uses_jitter_and_four_attempts():
+    """Async fetch retries should use four attempts and bounded jittered backoff."""
+    url = "https://csrc.nist.gov/reset"
+    request = scraper_module.httpx.Request("GET", url)
+    sleeps = []
+    jitter_calls = []
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = 0
+
+        async def get(self, requested_url):
+            assert requested_url == url, "fetch_with_retry should request the target URL"
+            self.calls += 1
+            raise scraper_module.httpx.RequestError("connection reset", request=request)
+
+    async def fake_sleep(wait):
+        sleeps.append(wait)
+
+    def fake_uniform(start, end):
+        jitter_calls.append((start, end))
+        return 1.25
+
+    original_sleep = scraper_module.asyncio.sleep
+    original_uniform = scraper_module.random.uniform
+    scraper_module.asyncio.sleep = fake_sleep
+    scraper_module.random.uniform = fake_uniform
+    try:
+        client = FakeClient()
+        result = asyncio.run(scraper_module.fetch_with_retry(client, url))
+    finally:
+        scraper_module.asyncio.sleep = original_sleep
+        scraper_module.random.uniform = original_uniform
+
+    assert result is None, "Exhausted retries should return None"
+    assert client.calls == 4, "fetch_with_retry should default to four attempts"
+    assert jitter_calls == [(0, 1.5), (0, 1.5), (0, 1.5)], "Each retry sleep should request jitter bounds"
+    assert sleeps == [3.25, 5.25, 9.25], "Retry sleeps should include exponential backoff plus jitter"
+    for attempt, wait in enumerate(sleeps):
+        base = 2 ** (attempt + 1)
+        assert 0 <= wait - base <= 1.5, "Retry jitter should stay within configured bounds"
+
+    print("✓ Async retry jitter/backoff test passed")
+
+
 def test_process_certificate_record_applies_cached_algorithm_provenance():
     """Cached algorithm reuse should still attach explicit provenance to outputs."""
     module = {
@@ -1378,13 +1424,14 @@ def test_build_certificate_artifacts_defers_uncached_failures():
     original_process = scraper_module.process_certificate_record_with_timeout
     scraper_module.process_certificate_record_with_timeout = fake_process
     try:
-        enriched, payloads, algorithms_map, stats = asyncio.run(
+        enriched, payloads, algorithms_map, stats, deferred = asyncio.run(
             build_certificate_artifacts(
                 modules,
                 "active",
                 "2026-06-01T00:00:00.000000Z",
                 "crawl4ai",
                 {"metadata": {}, "modules": {"active": {}}, "details": {}},
+                include_deferred=True,
             )
         )
     finally:
@@ -1395,6 +1442,13 @@ def test_build_certificate_artifacts_defers_uncached_failures():
     assert set(algorithms_map) == {6001}, "Deferred certificates should not get algorithm index entries"
     assert stats["certificates_deferred"] == 1, "Deferred certificates should be counted in metrics"
     assert stats["html_failed"] == 0, "Deferred records should not produce broken published artifacts"
+    assert deferred == [
+        {
+            "certificate_number": "6000",
+            "dataset": "active",
+            "reason": "certificate_detail_unavailable",
+        }
+    ], "Deferred certificate metadata should be returned to callers"
 
     print("✓ Deferred certificate filtering test passed")
 
@@ -1510,13 +1564,14 @@ def test_build_certificate_artifacts_bounds_active_tasks():
     scraper_module.CERT_FETCH_CONCURRENCY = 2
     scraper_module.PDF_FETCH_CONCURRENCY = 3
     try:
-        enriched, payloads, algorithms_map, stats = asyncio.run(
+        enriched, payloads, algorithms_map, stats, deferred = asyncio.run(
             build_certificate_artifacts(
                 modules,
                 "active",
                 "2026-04-12T03:10:00.961597Z",
                 "crawl4ai",
                 {"metadata": {}, "modules": {"active": {}}, "details": {}},
+                include_deferred=True,
             )
         )
     finally:
@@ -1530,8 +1585,161 @@ def test_build_certificate_artifacts_bounds_active_tasks():
     assert len(payloads) == len(modules), "Each fake detail payload should be retained"
     assert len(algorithms_map) == len(modules), "Each fake algorithm payload should be indexed"
     assert stats["html_refreshed"] == len(modules), "Stats should accumulate from bounded tasks"
+    assert deferred == [], "Successful bounded tasks should not report deferrals"
 
     print("✓ Bounded certificate scheduling test passed")
+
+
+def test_build_data_quality_report_marks_repeat_deferrals():
+    """Deferred certificates should be marked when also deferred in the previous run."""
+    metadata = {
+        "generated_at": "2026-04-12T03:10:00.961597Z",
+        "algorithm_source": "crawl4ai",
+        "extraction_metrics": build_extraction_metrics({}, {}),
+    }
+    previous_outputs = {
+        "metadata": {},
+        "modules": {"active": {}, "historical": {}},
+        "details": {},
+        "deferred_certificates": [
+            {
+                "certificate_number": "6000",
+                "dataset": "active",
+                "reason": "certificate_detail_unavailable",
+                "repeat": False,
+            }
+        ],
+    }
+    deferred = [
+        {
+            "certificate_number": "6000",
+            "dataset": "active",
+            "reason": "certificate_detail_unavailable",
+        },
+        {
+            "certificate_number": "7000",
+            "dataset": "historical",
+            "reason": "algorithm_unavailable",
+        },
+    ]
+
+    stderr = io.StringIO()
+    original_stderr = sys.stderr
+    sys.stderr = stderr
+    try:
+        report = build_data_quality_report(
+            metadata,
+            [],
+            [],
+            {},
+            previous_outputs,
+            {},
+            {},
+            deferred,
+        )
+    finally:
+        sys.stderr = original_stderr
+
+    assert report["summary"]["deferred"] == 2, "Deferred summary count should match deferred list"
+    assert report["deferred_certificates"][0]["repeat"] is True, "Consecutive deferral should be marked repeat"
+    assert report["deferred_certificates"][1]["repeat"] is False, "New deferral should not be marked repeat"
+    assert (
+        "Warning: certificate 6000 deferred in consecutive runs" in stderr.getvalue()
+    ), "Repeat deferrals should emit a warning"
+
+    print("✓ Repeat deferral marking test passed")
+
+
+def test_build_data_quality_report_algorithm_coverage_buckets():
+    """Algorithm coverage should classify every zero-algorithm certificate bucket."""
+    metadata = {
+        "generated_at": "2026-04-12T03:10:00.961597Z",
+        "algorithm_source": "crawl4ai",
+        "extraction_metrics": build_extraction_metrics({}, {}),
+    }
+    modules = [
+        {
+            "Certificate Number": "6100",
+            "Vendor Name": "Example Vendor",
+            "Module Name": "Covered Module",
+            "algorithms": ["AES"],
+            "detail_available": True,
+        },
+        {
+            "Certificate Number": "6101",
+            "Vendor Name": "Example Vendor",
+            "Module Name": "Cached Empty Module",
+            "algorithms": [],
+            "detail_available": True,
+            "algorithm_extraction": {
+                "status": "cached",
+                "source": "crawl4ai",
+                "cached": True,
+            },
+        },
+        {
+            "Certificate Number": "6102",
+            "Vendor Name": "Example Vendor",
+            "Module Name": "Explicit Empty Module",
+            "algorithms": [],
+            "detail_available": True,
+            "algorithm_extraction": {
+                "status": "miss",
+                "source": "security_policy_pdf",
+                "cached": False,
+                "attempts": [{"source": "security_policy_pdf", "status": "no_algorithms"}],
+            },
+        },
+        {
+            "Certificate Number": "6103",
+            "Vendor Name": "Example Vendor",
+            "Module Name": "Skipped Module",
+            "algorithms": [],
+            "detail_available": True,
+            "algorithm_extraction": {
+                "status": "skipped",
+                "source": "none",
+                "cached": False,
+            },
+        },
+        {
+            "Certificate Number": "6104",
+            "Vendor Name": "Example Vendor",
+            "Module Name": "Other Empty Module",
+            "algorithms": [],
+            "detail_available": True,
+            "algorithm_extraction": {
+                "status": "miss",
+                "source": "crawl4ai",
+                "cached": False,
+                "attempts": [{"source": "crawl4ai", "status": "no_text"}],
+            },
+        },
+    ]
+
+    report = build_data_quality_report(
+        metadata,
+        modules,
+        [],
+        {},
+        {"metadata": {}, "modules": {"active": {}}, "details": {}},
+        {},
+        {},
+        [],
+    )
+
+    coverage = report["algorithm_coverage"]
+    assert coverage["total_certificates"] == 5, "Coverage should count all active and historical certs"
+    assert coverage["certificates_with_algorithms"] == 1, "Coverage should count certs with extracted algorithms"
+    assert coverage["coverage_rate"] == 0.2, "Coverage rate should be rounded to four decimals"
+    assert coverage["zero_algorithm_certificates"] == {
+        "cached_no_attempts": 1,
+        "explicit_no_algorithms": 1,
+        "source_none": 1,
+        "other": 1,
+    }, "Zero-algorithm buckets should classify all empty algorithm records"
+
+    print("✓ Algorithm coverage classification test passed")
 
 
 def test_prune_orphan_certificate_details():
@@ -1776,6 +1984,19 @@ def test_data_quality_search_indexes_and_examples():
     assert report["summary"]["changed_certificates"] == 1, "Summary change should be listed as changed certificate"
     assert report["summary"]["fallback_usage"] == 1, "Fallback extraction should be listed"
     assert report["summary"]["misses"] == 1, "Historical algorithm miss should be listed"
+    assert report["summary"]["deferred"] == 0, "No deferred certificates should be reported for this fixture"
+    assert report["deferred_certificates"] == [], "Deferred certificate list should be present and empty"
+    assert report["algorithm_coverage"] == {
+        "total_certificates": 2,
+        "certificates_with_algorithms": 1,
+        "coverage_rate": 0.5,
+        "zero_algorithm_certificates": {
+            "cached_no_attempts": 0,
+            "explicit_no_algorithms": 0,
+            "source_none": 0,
+            "other": 1,
+        },
+    }, "Algorithm coverage should summarize zero-algorithm certificates"
     assert report["update_monitor"]["next_scheduled_run"] == "2026-04-19T02:00:00Z", "Next weekly run should be Sunday 02:00 UTC"
     checks = {
         check["name"]: check
@@ -1962,6 +2183,11 @@ def test_generate_agent_docs():
     assert schema_artifacts["api/schemas/modules-in-process.schema.json"]["properties"]["modules_in_process"]["items"]["$ref"] == "/api/schemas/module-in-process.schema.json", "Modules-in-process response should use its own row schema"
     assert schema_artifacts["api/schemas/module.schema.json"]["properties"]["algorithm_extraction"]["type"] == "object", "Module schema should include extraction provenance"
     assert schema_artifacts["api/schemas/certificate-detail.schema.json"]["properties"]["certificate"]["properties"]["algorithm_extraction"]["type"] == "object", "Certificate detail schema should include extraction provenance"
+    data_quality_schema = schema_artifacts["api/schemas/data-quality.schema.json"]
+    assert "deferred_certificates" in data_quality_schema["properties"], "Data quality schema should document deferred certificates"
+    assert "algorithm_coverage" in data_quality_schema["properties"], "Data quality schema should document algorithm coverage"
+    assert "deferred_certificates" not in data_quality_schema["required"], "Deferred certificates should remain optional for old artifacts"
+    assert "algorithm_coverage" not in data_quality_schema["required"], "Algorithm coverage should remain optional for old artifacts"
 
     openapi = generate_openapi_spec(
         [sample_module],
@@ -2021,12 +2247,15 @@ def main():
         test_algorithm_extraction_provenance_and_metrics()
         test_fetch_policy_pdf_bytes_reuses_in_run_cache()
         test_fetch_policy_pdf_bytes_shields_shared_cache_task_from_cancellation()
+        test_fetch_with_retry_uses_jitter_and_four_attempts()
         test_process_certificate_record_applies_cached_algorithm_provenance()
         test_process_certificate_record_timeout_preserves_cached_data()
         test_process_certificate_record_preserves_cache_after_refresh_failure()
         test_build_certificate_artifacts_defers_uncached_failures()
         test_module_rows_with_cache_fallback_preserves_previous_top_level_list()
         test_build_certificate_artifacts_bounds_active_tasks()
+        test_build_data_quality_report_marks_repeat_deferrals()
+        test_build_data_quality_report_algorithm_coverage_buckets()
         test_prune_orphan_certificate_details()
         test_validate_generated_api_artifacts()
         test_build_certificate_index_payload()

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -6,6 +6,7 @@ Tests the parsing logic with sample HTML.
 
 import asyncio
 import io
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -19,6 +20,7 @@ from scraper import (
     build_certificate_artifacts,
     build_certificate_index_payload,
     build_certificate_fingerprint,
+    build_changes_feed,
     build_data_quality_report,
     build_examples_payload,
     build_extraction_metrics,
@@ -1760,6 +1762,160 @@ def test_prune_orphan_certificate_details():
     print("✓ Orphan certificate cleanup test passed")
 
 
+def change_feed_module(cert_number, dataset="active", validation_date="04/10/2026"):
+    """Build a minimal module row with stable fingerprint fields for change-feed tests."""
+    status = "Active" if dataset == "active" else "Historical"
+    return {
+        "Certificate Number": str(cert_number),
+        "Vendor Name": f"Vendor {cert_number}",
+        "Module Name": f"Module {cert_number}",
+        "Module Type": "Software",
+        "Validation Date": validation_date,
+        "standard": "FIPS 140-3",
+        "status": status,
+        "security_policy_url": (
+            "https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/"
+            f"documents/security-policies/140sp{cert_number}.pdf"
+        ),
+        "certificate_detail_url": (
+            "https://csrc.nist.gov/projects/cryptographic-module-validation-program/"
+            f"certificate/{cert_number}"
+        ),
+        "detail_available": True,
+    }
+
+
+def test_build_changes_feed_first_run_empty_diffs():
+    """First runs should not classify every existing certificate as newly added."""
+    metadata = {"generated_at": "2026-04-12T03:10:00.961597Z", "version": "3.0"}
+    feed = build_changes_feed(
+        metadata,
+        [change_feed_module(100)],
+        [change_feed_module(200, "historical")],
+        {"modules": {"active": {}, "historical": {}}},
+        None,
+    )
+
+    assert feed["metadata"] == metadata, "Changes feed should embed shared metadata"
+    assert feed["max_runs"] == 26, "Changes feed should retain 26 runs"
+    assert feed["total_runs"] == 1, "First changes feed should report one run"
+    assert len(feed["runs"]) == 1, "First changes feed should include the current run"
+    entry = feed["runs"][0]
+    assert entry["added_active"] == [], "First run should not mark active certificates as added"
+    assert entry["added_historical"] == [], "First run should not mark historical certificates as added"
+    assert entry["removed"] == [], "First run should not mark removals"
+    assert entry["changed"] == [], "First run should not mark summary changes"
+    assert entry["counts"] == {
+        "added_active": 0,
+        "added_historical": 0,
+        "removed": 0,
+        "changed": 0,
+    }, "First run counts should be zeroed"
+
+    print("✓ Changes feed first-run behavior test passed")
+
+
+def test_build_changes_feed_appends_current_diff():
+    """Changes feed should prepend the current diff and preserve prior entries."""
+    metadata = {"generated_at": "2026-04-19T03:10:00.961597Z", "version": "3.0"}
+    previous_active = change_feed_module(100, validation_date="04/09/2026")
+    previous_historical = {
+        200: change_feed_module(200, "historical"),
+        300: change_feed_module(300, "historical"),
+    }
+    previous_changes = {
+        "metadata": {"generated_at": "2026-04-12T03:10:00.961597Z"},
+        "max_runs": 26,
+        "total_runs": 1,
+        "runs": [
+            {
+                "generated_at": "2026-04-12T03:10:00.961597Z",
+                "added_active": [],
+                "added_historical": [],
+                "removed": [],
+                "changed": [],
+                "counts": {
+                    "added_active": 0,
+                    "added_historical": 0,
+                    "removed": 0,
+                    "changed": 0,
+                },
+            }
+        ],
+    }
+
+    feed = build_changes_feed(
+        metadata,
+        [change_feed_module(100), change_feed_module(400)],
+        [change_feed_module(300, "historical")],
+        {
+            "modules": {
+                "active": {100: previous_active},
+                "historical": previous_historical,
+            }
+        },
+        previous_changes,
+    )
+
+    assert feed["total_runs"] == 2, "Appended feed should increment total run count"
+    assert [entry["generated_at"] for entry in feed["runs"]] == [
+        "2026-04-19T03:10:00.961597Z",
+        "2026-04-12T03:10:00.961597Z",
+    ], "Changes feed should be newest-first"
+    entry = feed["runs"][0]
+    assert entry["added_active"] == ["400"], "New active certificate should be listed"
+    assert entry["added_historical"] == [], "No historical certificate was added"
+    assert entry["removed"] == ["200"], "Removed historical certificate should be listed"
+    assert entry["changed"] == ["100"], "Summary-changed active certificate should be listed"
+    assert entry["counts"] == {
+        "added_active": 1,
+        "added_historical": 0,
+        "removed": 1,
+        "changed": 1,
+    }, "Current run counts should match list lengths"
+
+    print("✓ Changes feed append behavior test passed")
+
+
+def test_build_changes_feed_caps_runs():
+    """Changes feed should retain only the newest configured number of runs."""
+    metadata = {"generated_at": "2026-07-01T00:00:00.000000Z", "version": "3.0"}
+    previous_runs = [
+        {
+            "generated_at": f"2026-06-{day:02d}T00:00:00.000000Z",
+            "added_active": [],
+            "added_historical": [],
+            "removed": [],
+            "changed": [],
+            "counts": {
+                "added_active": 0,
+                "added_historical": 0,
+                "removed": 0,
+                "changed": 0,
+            },
+        }
+        for day in range(26, 0, -1)
+    ]
+    feed = build_changes_feed(
+        metadata,
+        [],
+        [],
+        {"modules": {"active": {}, "historical": {}}},
+        {"max_runs": 26, "total_runs": 26, "runs": previous_runs},
+    )
+
+    assert feed["total_runs"] == 27, "Capped feed should preserve cumulative total runs"
+    assert len(feed["runs"]) == 26, "Capped feed should keep only 26 entries"
+    assert feed["runs"][0]["generated_at"] == metadata["generated_at"], "Current run should be newest"
+    assert feed["runs"][-1]["generated_at"] == "2026-06-02T00:00:00.000000Z", "Oldest retained run mismatch"
+    assert all(
+        entry["generated_at"] != "2026-06-01T00:00:00.000000Z"
+        for entry in feed["runs"]
+    ), "Oldest previous run should be dropped"
+
+    print("✓ Changes feed cap behavior test passed")
+
+
 def test_validate_generated_api_artifacts():
     """Current checked-in generated API artifacts should be internally consistent."""
     errors = validate_api(
@@ -1770,6 +1926,61 @@ def test_validate_generated_api_artifacts():
     )
 
     assert errors == [], "Generated API artifact validation failed:\n" + "\n".join(errors[:20])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        temp_api = temp_root / "api"
+        temp_api.mkdir()
+        for relative_path in ("README.md", "openapi.json", "llms.txt", "llms-full.txt", "index.html"):
+            (temp_root / relative_path).symlink_to((Path(".") / relative_path).resolve())
+        for relative_path in (
+            "modules.json",
+            "historical-modules.json",
+            "modules-in-process.json",
+            "metadata.json",
+            "index.json",
+            "data-quality.json",
+            "examples.json",
+            "docs.md",
+        ):
+            (temp_api / relative_path).symlink_to((Path("api") / relative_path).resolve())
+        if (Path("api") / "algorithms.json").exists():
+            (temp_api / "algorithms.json").symlink_to((Path("api") / "algorithms.json").resolve())
+        for relative_path in ("certificates", "indexes", "schemas"):
+            (temp_api / relative_path).symlink_to((Path("api") / relative_path).resolve(), target_is_directory=True)
+
+        metadata = json.loads((Path("api") / "metadata.json").read_text(encoding="utf-8"))
+        changes_fixture = {
+            "metadata": metadata,
+            "max_runs": 26,
+            "total_runs": 1,
+            "runs": [
+                {
+                    "generated_at": metadata["generated_at"],
+                    "added_active": [],
+                    "added_historical": [],
+                    "removed": [],
+                    "changed": [],
+                    "counts": {
+                        "added_active": 0,
+                        "added_historical": 0,
+                        "removed": 0,
+                        "changed": 0,
+                    },
+                }
+            ],
+        }
+        (temp_api / "changes.json").write_text(
+            json.dumps(changes_fixture, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        errors = validate_api(
+            temp_root,
+            require_current_schema=True,
+            require_supported_algorithm_source=True,
+            require_data_quality_pass=True,
+        )
+        assert errors == [], "Generated API artifact validation with changes fixture failed:\n" + "\n".join(errors[:20])
 
     print("✓ Generated API artifact validation test passed")
 
@@ -2135,6 +2346,7 @@ def test_generate_agent_docs():
     assert "api/algorithms.json" in artifacts["llms.txt"], "llms.txt should reference algorithms endpoint when available"
     assert "api/certificates/index.json" in artifacts["llms.txt"], "llms.txt should reference certificate index endpoint"
     assert "api/data-quality.json" in artifacts["llms.txt"], "llms.txt should reference data quality endpoint"
+    assert "api/changes.json" in artifacts["llms.txt"], "llms.txt should reference changes endpoint"
     assert "api/examples.json" in artifacts["llms.txt"], "llms.txt should reference examples endpoint"
     assert "api/indexes/vendors.json" in artifacts["llms.txt"], "llms.txt should reference split search indexes"
     assert 'href="api/docs.md"' in artifacts["index.html"], "Homepage should link to api/docs.md"
@@ -2146,6 +2358,7 @@ def test_generate_agent_docs():
     assert "GET api/certificates/{certificate}.json" in artifacts["api/docs.md"], "API docs should include certificate detail endpoint"
     assert "GET api/schemas/index.schema.json" in artifacts["api/docs.md"], "API docs should include JSON schema endpoint"
     assert "GET api/data-quality.json" in artifacts["api/docs.md"], "API docs should include data quality endpoint"
+    assert "GET api/changes.json" in artifacts["api/docs.md"], "API docs should include changes endpoint"
     assert "GET api/examples.json" in artifacts["api/docs.md"], "API docs should include examples endpoint"
     assert "GET api/indexes/vendors.json" in artifacts["api/docs.md"], "API docs should include split search indexes"
     assert "algorithm_extraction" in artifacts["api/docs.md"], "API docs should describe extraction provenance"
@@ -2157,9 +2370,11 @@ def test_generate_agent_docs():
     assert index_payload["schemas"]["certificate_index"] == "/api/schemas/certificate-index.schema.json", "Index payload should advertise certificate index schema"
     assert index_payload["schemas"]["certificate_detail"] == "/api/schemas/certificate-detail.schema.json", "Index payload should advertise certificate detail schema"
     assert index_payload["schemas"]["data_quality"] == "/api/schemas/data-quality.schema.json", "Index payload should advertise data quality schema"
+    assert index_payload["schemas"]["changes"] == "/api/schemas/changes.schema.json", "Index payload should advertise changes schema"
     assert index_payload["schemas"]["examples"] == "/api/schemas/examples.schema.json", "Index payload should advertise examples schema"
     assert index_payload["schemas"]["search_index"] == "/api/schemas/search-index.schema.json", "Index payload should advertise search index schema"
     assert index_payload["endpoints"]["data_quality"] == "/api/data-quality.json", "Index payload should advertise data quality endpoint"
+    assert index_payload["endpoints"]["changes"] == "/api/changes.json", "Index payload should advertise changes endpoint"
     assert index_payload["endpoints"]["examples"] == "/api/examples.json", "Index payload should advertise examples endpoint"
     assert index_payload["endpoints"]["vendor_index"] == "/api/indexes/vendors.json", "Index payload should advertise vendor index"
     assert index_payload["features"]["markdown_api_docs"] is True, "Index payload should advertise Markdown docs support"
@@ -2167,6 +2382,7 @@ def test_generate_agent_docs():
     assert index_payload["features"]["extraction_metrics"] is True, "Index payload should advertise extraction metrics"
     assert index_payload["features"]["certificate_index"] is True, "Index payload should advertise certificate index support"
     assert index_payload["features"]["data_quality_report"] is True, "Index payload should advertise data quality support"
+    assert index_payload["features"]["changes_feed"] is True, "Index payload should advertise changes feed support"
     assert index_payload["features"]["consumer_examples"] is True, "Index payload should advertise examples support"
     assert index_payload["features"]["search_indexes"] is True, "Index payload should advertise search index support"
     assert index_payload["features"]["json_schemas"] is True, "Index payload should advertise JSON schema support"
@@ -2177,6 +2393,7 @@ def test_generate_agent_docs():
     assert "api/schemas/certificate-index.schema.json" in schema_artifacts, "Missing certificate index JSON schema"
     assert "api/schemas/certificate-detail.schema.json" in schema_artifacts, "Missing certificate detail JSON schema"
     assert "api/schemas/data-quality.schema.json" in schema_artifacts, "Missing data quality JSON schema"
+    assert "api/schemas/changes.schema.json" in schema_artifacts, "Missing changes JSON schema"
     assert "api/schemas/examples.schema.json" in schema_artifacts, "Missing examples JSON schema"
     assert "api/schemas/search-index.schema.json" in schema_artifacts, "Missing search index JSON schema"
     assert "api/schemas/algorithms.schema.json" in schema_artifacts, "Missing algorithms JSON schema"
@@ -2188,6 +2405,8 @@ def test_generate_agent_docs():
     assert "algorithm_coverage" in data_quality_schema["properties"], "Data quality schema should document algorithm coverage"
     assert "deferred_certificates" not in data_quality_schema["required"], "Deferred certificates should remain optional for old artifacts"
     assert "algorithm_coverage" not in data_quality_schema["required"], "Algorithm coverage should remain optional for old artifacts"
+    changes_schema = schema_artifacts["api/schemas/changes.schema.json"]
+    assert changes_schema["properties"]["max_runs"]["minimum"] == 1, "Changes schema should document max_runs"
 
     openapi = generate_openapi_spec(
         [sample_module],
@@ -2198,6 +2417,7 @@ def test_generate_agent_docs():
     assert "/api/algorithms.json" in openapi["paths"], "OpenAPI spec should include algorithms endpoint when available"
     assert "/api/certificates/index.json" in openapi["paths"], "OpenAPI spec should include certificate index endpoint"
     assert "/api/data-quality.json" in openapi["paths"], "OpenAPI spec should include data quality endpoint"
+    assert "/api/changes.json" in openapi["paths"], "OpenAPI spec should include changes endpoint"
     assert "/api/examples.json" in openapi["paths"], "OpenAPI spec should include examples endpoint"
     assert "/api/indexes/vendors.json" in openapi["paths"], "OpenAPI spec should include vendor index endpoint"
     assert openapi["components"]["schemas"]["Module"]["properties"]["detail_available"]["type"] == "boolean", "detail_available should be typed as boolean"
@@ -2257,6 +2477,9 @@ def main():
         test_build_data_quality_report_marks_repeat_deferrals()
         test_build_data_quality_report_algorithm_coverage_buckets()
         test_prune_orphan_certificate_details()
+        test_build_changes_feed_first_run_empty_diffs()
+        test_build_changes_feed_appends_current_diff()
+        test_build_changes_feed_caps_runs()
         test_validate_generated_api_artifacts()
         test_build_certificate_index_payload()
         test_data_quality_search_indexes_and_examples()

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -38,6 +38,7 @@ from scraper import (
     parse_algorithms_from_policy_markdown,
     parse_algorithms_from_policy_text,
     parse_certificate_detail_page,
+    parse_legacy_algorithm_rows,
     parse_modules_table,
     prepare_reused_detail_payload,
     process_certificate_record,
@@ -50,6 +51,27 @@ from validate_api import validate_api
 
 
 FIXTURE_DIR = Path(__file__).parent / "tests" / "fixtures" / "nist_security_policies"
+FIPS_140_2_5152_EXPECTED_DETAILED = [
+    "AES Cert. #A3424",
+    "DRBG Cert. #A3424",
+    "ECDSA Cert. #A3424",
+    "HMAC Cert. #A3424",
+    "KAS Cert. #A3424",
+    "RSA Cert. #A3424",
+    "SHS Cert. #A3424",
+]
+FIPS_140_2_5152_EXPECTED_CATEGORIES = [
+    "AES",
+    "DRBG",
+    "ECDSA",
+    "HMAC",
+    "KAS",
+    "KDF",
+    "RSA",
+    "SHS",
+    "SSH",
+    "TLS",
+]
 
 
 def load_policy_fixture(name: str) -> str:
@@ -702,22 +724,52 @@ def test_parse_real_world_fips_140_2_policy_fixture():
 
     detailed, categories = parse_algorithms_from_policy_text(policy_text)
 
-    assert detailed == [], "Legacy FIPS 140-2 fixture should use coarse categories"
-    assert categories == [
-        "AES",
-        "DRBG",
-        "ECDSA",
-        "HMAC",
-        "KAS",
-        "KDF",
-        "RSA",
-        "SHS",
-        "SSH",
-        "TLS",
-    ], "Expected normalized FIPS 140-2 categories"
+    assert detailed == FIPS_140_2_5152_EXPECTED_DETAILED, "Expected legacy certificate-backed detail rows"
+    assert categories == FIPS_140_2_5152_EXPECTED_CATEGORIES, "Expected normalized FIPS 140-2 categories"
     assert "DES" not in categories, "Allowed/non-approved section must not leak into approved categories"
 
     print("✓ Real-world FIPS 140-2 fixture parsing test passed")
+
+
+def test_parse_real_world_fips_140_2_policy_fixture_without_algorithm_heading():
+    """Legacy parser should start from the approved table intro if the heading is missing."""
+    policy_text = load_policy_fixture("5152_fips_140_2_algorithms_no_heading.txt")
+
+    detailed, categories = parse_algorithms_from_policy_text(policy_text)
+
+    assert detailed == FIPS_140_2_5152_EXPECTED_DETAILED, "Expected intro-start fixture detail rows"
+    assert categories == FIPS_140_2_5152_EXPECTED_CATEGORIES, "Expected intro-start fixture categories"
+    assert "DES" not in categories, "Allowed/non-approved section must not leak into approved categories"
+
+    print("✓ FIPS 140-2 intro-sentence legacy parsing test passed")
+
+
+def test_parse_real_world_fips_140_2_policy_fixture_unnumbered_allowed_stop():
+    """Legacy parser should stop at unnumbered allowed-algorithm headings."""
+    policy_text = load_policy_fixture("5152_fips_140_2_algorithms_unnumbered_allowed.txt")
+
+    detailed, categories = parse_algorithms_from_policy_text(policy_text)
+
+    assert detailed == FIPS_140_2_5152_EXPECTED_DETAILED, "Expected unnumbered-stop fixture detail rows"
+    assert categories == FIPS_140_2_5152_EXPECTED_CATEGORIES, "Expected unnumbered-stop fixture categories"
+    assert "DES" not in categories, "Unnumbered Allowed Algorithms section must not leak DES"
+
+    print("✓ FIPS 140-2 unnumbered allowed-section stop test passed")
+
+
+def test_parse_legacy_algorithm_rows_extracts_certificate_rows():
+    """Legacy row extraction should keep approved algorithm rows with certificate references."""
+    policy_text = load_policy_fixture("5152_fips_140_2_algorithms.txt")
+    section = extract_legacy_algorithm_section(policy_text)
+
+    detailed = parse_legacy_algorithm_rows(section)
+
+    assert detailed == FIPS_140_2_5152_EXPECTED_DETAILED, "Expected certificate-backed legacy detail rows"
+    assert "AES Cert. #A3424" in detailed, "Expected AES certificate row"
+    assert "SHS Cert. #A3424" in detailed, "Expected SHS certificate row"
+    assert all("Triple-DES" not in entry for entry in detailed), "Allowed Triple-DES row must not leak into details"
+
+    print("✓ Legacy certificate-row extraction test passed")
 
 
 def test_parse_algorithms_from_policy_markdown():
@@ -2458,6 +2510,9 @@ def main():
         test_extract_legacy_algorithm_section_prefers_body_over_toc()
         test_parse_real_world_fips_140_3_policy_fixture()
         test_parse_real_world_fips_140_2_policy_fixture()
+        test_parse_real_world_fips_140_2_policy_fixture_without_algorithm_heading()
+        test_parse_real_world_fips_140_2_policy_fixture_unnumbered_allowed_stop()
+        test_parse_legacy_algorithm_rows_extracts_certificate_rows()
         test_parse_algorithms_from_policy_markdown()
         test_extract_text_from_crawl4ai_html()
         test_extract_text_from_crawl4ai_process_result()

--- a/test_scraper.py
+++ b/test_scraper.py
@@ -5,7 +5,6 @@ Tests the parsing logic with sample HTML.
 """
 
 import asyncio
-import json
 import sys
 import tempfile
 from pathlib import Path

--- a/tests/fixtures/nist_security_policies/5152_fips_140_2_algorithms_no_heading.txt
+++ b/tests/fixtures/nist_security_policies/5152_fips_140_2_algorithms_no_heading.txt
@@ -1,0 +1,20 @@
+Source: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp5152.pdf
+Certificate: 5152
+Standard: FIPS 140-2
+
+Table 10 lists the FIPS Approved cryptographic algorithms used by the module.
+Algorithm
+AES Cert. #A3424
+DRBG Cert. #A3424
+ECDSA Cert. #A3424
+HMAC Cert. #A3424
+KAS Cert. #A3424
+KDF TLS
+RSA Cert. #A3424
+SHS Cert. #A3424
+SSH KDF
+
+3.5 Allowed Algorithms
+Table 11 describes the non-approved but allowed algorithms in FIPS mode.
+Algorithm
+Triple-DES

--- a/tests/fixtures/nist_security_policies/5152_fips_140_2_algorithms_unnumbered_allowed.txt
+++ b/tests/fixtures/nist_security_policies/5152_fips_140_2_algorithms_unnumbered_allowed.txt
@@ -1,0 +1,21 @@
+Source: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp5152.pdf
+Certificate: 5152
+Standard: FIPS 140-2
+
+3.4 Algorithms
+Table 10 lists the FIPS Approved cryptographic algorithms used by the module.
+Algorithm
+AES Cert. #A3424
+DRBG Cert. #A3424
+ECDSA Cert. #A3424
+HMAC Cert. #A3424
+KAS Cert. #A3424
+KDF TLS
+RSA Cert. #A3424
+SHS Cert. #A3424
+SSH KDF
+
+Allowed Algorithms
+Table 11 describes the non-approved but allowed algorithms in FIPS mode.
+Algorithm
+Triple-DES

--- a/validate_api.py
+++ b/validate_api.py
@@ -385,6 +385,7 @@ def validate_data_quality_report(
     root: Path,
     metadata: Dict,
     expected_datasets: Dict[int, str],
+    expected_algorithms: Dict[int, List[str]],
     errors: List[str],
     require_data_quality_pass: bool = False,
 ) -> None:
@@ -418,6 +419,76 @@ def validate_data_quality_report(
             add_error(errors, record.get("dataset") == expected_datasets.get(cert_number), f"{label}: dataset mismatch")
             add_error(errors, record.get("path") == f"/api/certificates/{cert_number}.json", f"{label}: path mismatch")
             add_error(errors, bool(record.get("reason")), f"{label}: missing reason")
+
+    deferred_records = payload.get("deferred_certificates")
+    if "deferred_certificates" in payload:
+        add_error(errors, isinstance(deferred_records, list), "api/data-quality.json: deferred_certificates must be a list")
+        if isinstance(deferred_records, list):
+            if "deferred" in summary:
+                add_error(
+                    errors,
+                    summary.get("deferred") == len(deferred_records),
+                    "api/data-quality.json: summary.deferred count mismatch",
+                )
+            for index, record in enumerate(deferred_records):
+                label = f"api/data-quality.json: deferred_certificates[{index}]"
+                add_error(errors, isinstance(record, dict), f"{label}: record must be an object")
+                if not isinstance(record, dict):
+                    continue
+                for field in ("certificate_number", "dataset", "reason", "repeat"):
+                    add_error(errors, field in record, f"{label}: missing {field}")
+                cert_number = record.get("certificate_number")
+                add_error(
+                    errors,
+                    cert_number is None or isinstance(cert_number, str),
+                    f"{label}: certificate_number must be a string or null",
+                )
+                add_error(errors, record.get("dataset") in {"active", "historical"}, f"{label}: invalid dataset")
+                add_error(errors, isinstance(record.get("reason"), str) and bool(record.get("reason")), f"{label}: missing reason")
+                add_error(errors, isinstance(record.get("repeat"), bool), f"{label}: repeat must be a boolean")
+
+    algorithm_coverage = payload.get("algorithm_coverage")
+    if "algorithm_coverage" in payload:
+        label = "api/data-quality.json: algorithm_coverage"
+        add_error(errors, isinstance(algorithm_coverage, dict), f"{label} must be an object")
+        if isinstance(algorithm_coverage, dict):
+            total = algorithm_coverage.get("total_certificates")
+            with_algorithms = algorithm_coverage.get("certificates_with_algorithms")
+            coverage_rate = algorithm_coverage.get("coverage_rate")
+            zero_buckets = algorithm_coverage.get("zero_algorithm_certificates")
+            add_error(errors, isinstance(total, int) and total >= 0, f"{label}.total_certificates must be a non-negative integer")
+            add_error(
+                errors,
+                isinstance(with_algorithms, int) and with_algorithms >= 0,
+                f"{label}.certificates_with_algorithms must be a non-negative integer",
+            )
+            add_error(
+                errors,
+                isinstance(coverage_rate, (int, float)) and 0 <= coverage_rate <= 1,
+                f"{label}.coverage_rate must be between 0 and 1",
+            )
+            add_error(errors, isinstance(zero_buckets, dict), f"{label}.zero_algorithm_certificates must be an object")
+            if isinstance(total, int):
+                add_error(errors, total == len(expected_datasets), f"{label}.total_certificates mismatch")
+            if isinstance(with_algorithms, int):
+                add_error(
+                    errors,
+                    with_algorithms == len(expected_algorithms),
+                    f"{label}.certificates_with_algorithms mismatch",
+                )
+            if isinstance(zero_buckets, dict):
+                bucket_total = 0
+                for bucket in ("cached_no_attempts", "explicit_no_algorithms", "source_none", "other"):
+                    value = zero_buckets.get(bucket)
+                    add_error(errors, isinstance(value, int) and value >= 0, f"{label}.{bucket} must be a non-negative integer")
+                    if isinstance(value, int):
+                        bucket_total += value
+                if isinstance(total, int) and isinstance(with_algorithms, int):
+                    add_error(
+                        errors,
+                        bucket_total == total - with_algorithms,
+                        f"{label}.zero_algorithm_certificates bucket total mismatch",
+                    )
 
     update_monitor = payload.get("update_monitor")
     add_error(errors, isinstance(update_monitor, dict), "api/data-quality.json: update_monitor must be an object")
@@ -728,7 +799,7 @@ def validate_api(
     )
     validate_certificate_index(root, metadata, expected_datasets, expected_algorithms, errors)
     validate_algorithms_summary(root, metadata, expected_algorithms, errors)
-    validate_data_quality_report(root, metadata, expected_datasets, errors, require_data_quality_pass)
+    validate_data_quality_report(root, metadata, expected_datasets, expected_algorithms, errors, require_data_quality_pass)
     validate_examples_payload(root, metadata, errors)
     validate_search_indexes(root, metadata, expected_datasets, errors)
     validate_docs_and_index(

--- a/validate_api.py
+++ b/validate_api.py
@@ -26,6 +26,8 @@ REQUIRED_TOP_LEVEL_FILES = (
     "api/docs.md",
     "index.html",
 )
+# api/changes.json is validated when present, but stays optional until after
+# the first scheduled workflow publishes it into the generated artifacts.
 
 DETAIL_REQUIRED_FIELDS = (
     "certificate_number",
@@ -79,6 +81,8 @@ JSON_SCHEMA_FILES = (
     "api/schemas/examples.schema.json",
     "api/schemas/search-index.schema.json",
 )
+# api/schemas/changes.schema.json follows the optional changes feed and becomes
+# required-eligible after the first published artifact set includes it.
 
 SEARCH_INDEX_FILES = (
     ("vendors", "vendor_name", "api/indexes/vendors.json"),
@@ -517,6 +521,77 @@ def validate_data_quality_report(
                     add_error(errors, check.get("status") == "pass", f"{label}: status must be pass")
 
 
+def validate_changes_feed(root: Path, metadata: Dict, errors: List[str]) -> None:
+    """Validate api/changes.json when the optional feed has been published."""
+    changes_path = root / "api" / "changes.json"
+    if not changes_path.exists():
+        return
+
+    payload = load_json(changes_path, errors)
+    if payload is None:
+        return
+
+    add_error(errors, isinstance(payload.get("metadata"), dict), "api/changes.json: metadata must be an object")
+    if isinstance(payload.get("metadata"), dict):
+        add_error(errors, payload.get("metadata") == metadata, "api/changes.json: embedded metadata does not match api/metadata.json")
+
+    max_runs = payload.get("max_runs")
+    total_runs = payload.get("total_runs")
+    runs = payload.get("runs")
+    add_error(errors, isinstance(max_runs, int) and max_runs > 0, "api/changes.json: max_runs must be a positive integer")
+    add_error(errors, isinstance(total_runs, int) and total_runs >= 0, "api/changes.json: total_runs must be a non-negative integer")
+    add_error(errors, isinstance(runs, list), "api/changes.json: runs must be a list")
+    if not isinstance(runs, list):
+        return
+
+    if isinstance(max_runs, int) and max_runs > 0:
+        add_error(errors, len(runs) <= max_runs, "api/changes.json: runs exceeds max_runs")
+    if isinstance(total_runs, int):
+        add_error(errors, total_runs >= len(runs), "api/changes.json: total_runs must be at least len(runs)")
+
+    previous_generated_at: Optional[str] = None
+    list_fields = ("added_active", "added_historical", "removed", "changed")
+    for index, entry in enumerate(runs):
+        label = f"api/changes.json: runs[{index}]"
+        add_error(errors, isinstance(entry, dict), f"{label}: entry must be an object")
+        if not isinstance(entry, dict):
+            continue
+
+        for field in ("generated_at", *list_fields, "counts"):
+            add_error(errors, field in entry, f"{label}: missing {field}")
+
+        generated_at = entry.get("generated_at")
+        add_error(errors, isinstance(generated_at, str) and bool(generated_at), f"{label}: generated_at must be a non-empty string")
+        if isinstance(generated_at, str) and previous_generated_at is not None:
+            add_error(errors, generated_at <= previous_generated_at, f"{label}: runs must be newest-first by generated_at")
+        if isinstance(generated_at, str):
+            previous_generated_at = generated_at
+
+        field_lengths: Dict[str, int] = {}
+        for field in list_fields:
+            value = entry.get(field)
+            add_error(errors, isinstance(value, list), f"{label}: {field} must be a list")
+            if not isinstance(value, list):
+                continue
+            field_lengths[field] = len(value)
+            for value_index, cert_number in enumerate(value):
+                add_error(
+                    errors,
+                    isinstance(cert_number, str) and cert_number.isdigit(),
+                    f"{label}: {field}[{value_index}] must be a numeric string",
+                )
+
+        counts = entry.get("counts")
+        add_error(errors, isinstance(counts, dict), f"{label}: counts must be an object")
+        if not isinstance(counts, dict):
+            continue
+        for field in list_fields:
+            count = counts.get(field)
+            add_error(errors, isinstance(count, int) and count >= 0, f"{label}: counts.{field} must be a non-negative integer")
+            if field in field_lengths and isinstance(count, int):
+                add_error(errors, count == field_lengths[field], f"{label}: counts.{field} does not match {field} length")
+
+
 def validate_examples_payload(root: Path, metadata: Dict, errors: List[str]) -> None:
     """Validate api/examples.json includes all advertised example families."""
     payload = load_json(root / "api" / "examples.json", errors)
@@ -800,6 +875,7 @@ def validate_api(
     validate_certificate_index(root, metadata, expected_datasets, expected_algorithms, errors)
     validate_algorithms_summary(root, metadata, expected_algorithms, errors)
     validate_data_quality_report(root, metadata, expected_datasets, expected_algorithms, errors, require_data_quality_pass)
+    validate_changes_feed(root, metadata, errors)
     validate_examples_payload(root, metadata, errors)
     validate_search_indexes(root, metadata, expected_datasets, errors)
     validate_docs_and_index(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the full improvement plan across pipeline reliability, project health, and end-data quality (one commit per area):

### Pipeline reliability & observability
- **Failure alerting**: `update-data.yml` now opens (or comments on) a `data-refresh-failure` issue whenever the scheduled refresh fails — no more silent 7-week outages
- **Freshness monitor**: new `data-freshness.yml` workflow (Mondays 12:00 UTC) fetches the live GitHub Pages `metadata.json`, fails if it is out of sync with the repo or older than 8 days, and opens a `data-freshness` issue
- **Retry tuning**: certificate fetch concurrency lowered 16 → 8, retry backoff gets random jitter, async retries raised 3 → 4 (NIST resets connections under concurrent load)
- **Deferred-certificate visibility**: `api/data-quality.json` now publishes a `deferred_certificates` list with `repeat: true` marking for certs deferred in consecutive runs (informational only — does not affect the strict quality gate)

### Project health
- **Ruff lint** (default E/F rules) added to CI; existing violations fixed
- **Pytest** adopted in CI (`python -m pytest test_scraper.py`); the legacy `python test_scraper.py` runner still works
- **`requirements-dev.txt`**: the Validate job no longer installs the heavy crawl4ai/Playwright stack (tests mock all network I/O)
- **Pinned dependencies** in `requirements.txt`, with **Dependabot** (pip + github-actions, weekly) to propose bumps
- **`modal_scrape.py`** now compiled in CI

### End data quality
- **Change feed**: new `api/changes.json` endpoint — a rolling 26-run changelog of added/removed/changed certificates per refresh, plus schema, docs, and OpenAPI entries (file first appears after the next scheduled run; validation treats it as optional until then)
- **Algorithm coverage report**: `api/data-quality.json` gains an `algorithm_coverage` object (currently 32.2% coverage; 3,626 zero-algorithm certs classified into cached/no-attempts, explicit no-algorithms, source-none buckets) so coverage gaps are visible instead of hidden behind `misses: 0`
- **Legacy FIPS 140-2 parser hardening**: recovers algorithm sections when PDF extraction drops numbered headings, stops correctly at unnumbered "Allowed Algorithms" sections (prevents Triple-DES leaking a false "DES" category), and now extracts detailed rows (`AES Cert. #A3424`) from legacy policies — with new derived fixtures and tests

### Deliberately not included
- **gh-pages repo split** (moving data artifacts out of `main`): requires a repository-settings change to the Pages source that only an admin can make, and is a disruptive migration best done standalone
- **Detail-page HTML algorithm extraction**: scouting showed no offline fixture models an algorithm table on certificate detail pages; implementing it without live NIST access would be speculative

## Validation
- `ruff check .` clean; `pytest test_scraper.py` 44 passed; legacy runner passes
- `validate_api.py --require-current-schema --require-supported-algorithm-source --require-data-quality-pass` passes against checked-in artifacts
- Offline end-to-end scraper run (NIST unreachable → cache fallback) generated all artifacts including the new `changes.json` and enriched data-quality report, and passed strict validation
- All new data-quality/changes fields are optional in validation until the next scheduled run publishes them, so CI stays green before and after
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f03b8-ec5b-7764-b11a-b1fbe0bc5101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f03b8-ec5b-7764-b11a-b1fbe0bc5101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

